### PR TITLE
fix: 修复 grid-4 数字溢出和 frame 内容越界问题

### DIFF
--- a/assets/template.html
+++ b/assets/template.html
@@ -190,7 +190,7 @@
      ============================================================ */
 
   /* ---------- .frame：每页主内容容器 ---------- */
-  .frame{flex:1;display:flex;flex-direction:column;min-height:0}
+  .frame{flex:1;display:flex;flex-direction:column;min-height:0;overflow:hidden}
   /* 当 .frame 同时加了 grid 类时，grid 的 display:grid 覆盖 flex */
   .frame.grid-2-7-5,
   .frame.grid-2-6-6,
@@ -294,8 +294,8 @@
     opacity:.72;
     margin-top:.6vh;
   }
-  /* 当 stat-card 用于 grid-4（2x2），数字可以更大 */
-  .grid-4 .stat-card .stat-nb{font-size:7.5vw}
+  /* 当 stat-card 用于 grid-4（2x2），数字适度放大；若页面有标题+引文在上方，可内联 style 覆盖为更小值 */
+  .grid-4 .stat-card .stat-nb{font-size:5vw}
   /* 当只有 3 个，字也可以稍大 */
   .grid-3 .stat-card .stat-nb{font-size:6.8vw}
 


### PR DESCRIPTION
## 背景

用这个 skill 做了一个 9 页的课程介绍 PPT，碰到了两个布局 bug，页面静默破掉，没有任何报错。修复分享在这里。

## Bug 1：`.grid-4 .stat-card .stat-nb` 在有标题+引文的页面溢出

**问题：** stat 网格上方放了标题（`h-xl`）和引文（`lead`）之后，底部两个 stat-card 超出 `.frame` 范围，叠到 `.foot` 上面。页脚文字直接压在 stat-note 上，没有任何报错提示。

**原因：** `7.5vw` 在纯数字页没问题，但加上标题区之后总高超过 100vh。

**修复：** 改为 `5vw`。1440p/1920p/4K 下都能正常显示。如果是纯数字页需要更大字号，在具体的 `.stat-nb` 上内联 `style="font-size:6.5vw"` 覆盖即可，不影响其他页。

---

**Problem:** When a title and lead text appear above a `grid-4` stat grid on the same slide, the bottom row of stat cards clips into `.foot`. The footer text renders over the stat notes. No error, just broken visuals.

**Fix:** Reduced from `7.5vw` to `5vw`. Works at 1440p, 1920p, 4K. Stats-only slides that need larger numbers can override inline on the specific `.stat-nb`.

---

## Bug 2：`.frame` 缺少 `overflow:hidden`

**问题：** `.frame` 内容超出可用高度时，会直接渲染到 `.foot` 区域上面。问题是静默的，没有任何报错，视觉上就坏掉了。

**修复：** 加一行 `overflow:hidden`。防止整类问题，一行解决。

---

**Problem:** Without `overflow:hidden`, frame content that overflows the available height renders silently over `.foot`. One property prevents the whole category of failure.

---

## 改动 / Changes

两行 CSS，非破坏性。/ Two lines of CSS, non-breaking.

| 文件 | 改动 |
|---|---|
| `assets/template.html` | `.frame` 加 `overflow:hidden` |
| `assets/template.html` | `.grid-4 .stat-card .stat-nb` 从 `7.5vw` 改为 `5vw`，注释同步更新 |

---

## 最后

这个 skill 设计得真的好。WebGL 双背景的实现方式很聪明，五套主题把颜色决策权收走反而是对的，layout 库在实际项目里真的能用。我用它跑了一个真实项目，这两个 bug 是遇到的唯一问题。谢谢你做了这个，分享出来。

This skill is well-built. The WebGL dual-canvas approach is clever, the five-theme constraint saves slides from bad color decisions, and the layout library holds up on real projects. I ran it on an actual build — these two bugs were the only friction I hit. Thanks for making and sharing this.