### PR TITLE
Image planning workflow

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,6 +13,8 @@ A [Claude Code / Claude Agent Skills](https://agentskills.io/) skill that genera
 - 📐 **Horizontal swipe navigation**: ← → arrows / scroll wheel / touch swipe / bottom dots / ESC for index
 - 🎨 **5 curated theme presets**: Ink Classic / Indigo Porcelain / Forest Ink / Kraft Paper / Dune
 - 🧩 **10 page layouts**: cover, act divider, big numbers, lead image + text, image grid, pipeline, hero question, big quote, before/after, image + text mix
+- 🖼 **Image planning, not generation**: decide per-slide image needs, return prompts / roles / ratios / filenames / paths / animations, then verify user-supplied assets
+- ◫ **Missing-image placeholders**: missing `images/...` files render as translucent placeholders in HTML
 - 📄 **Single HTML file** — no build, no server, open directly in the browser
 
 ## Fits / Doesn't fit
@@ -59,12 +61,12 @@ Once installed, Claude Code auto-detects the skill. Trigger phrases:
 
 The skill is a structured 6-step flow; Claude walks you through each:
 
-1. **Clarify intent** — 6-question checklist: audience, duration, source material, images, theme, hard constraints
-2. **Copy template** — `assets/template.html` → project folder, update `<title>`, swap theme vars
-3. **Fill content** — pick from 10 layout skeletons, paste, edit copy (with class-name pre-flight + theme rhythm plan)
-4. **Self-check** — match against `references/checklist.md`; P0 issues must all pass
-5. **Preview** — open the HTML in a browser
-6. **Iterate** — use inline styles to tune font size, height, spacing
+1. **Clarify intent** — 6-question checklist: audience, duration, source material, images, theme, hard constraints; if the user has no images, ask whether to reserve missing-image slots or build a text-only deck
+2. **Plan images and motion** — write `visual_intent` / `motion_level` per slide; only output an image requirement table when image slots are requested, and do not call image-generation APIs
+3. **Copy template** — `assets/template.html` → project folder, update `<title>`, swap theme vars
+4. **Fill content** — pick from 10 layout skeletons, edit copy / image paths, and keep placeholders only when image slots were requested
+5. **Self-check and image QA** — use `references/checklist.md`; check missing files, ratios, naming, style consistency, relevance, and readability
+6. **Preview / iterate** — open the HTML in a browser, then tune font size, height, spacing with inline styles
 
 Full spec in [`SKILL.md`](./SKILL.md).
 
@@ -79,6 +81,7 @@ guizang-ppt-skill/
 │   └── template.html     ← runnable seed HTML (CSS + WebGL + swipe JS pre-wired)
 └── references/
     ├── components.md     ← component catalog (type, color, grid, icons, callout, stat, pipeline)
+    ├── image-workflow.md ← image planning and QA (prompts, roles, ratios, placeholders)
     ├── layouts.md        ← 10 layout skeletons (paste-ready)
     ├── themes.md         ← 5 theme presets (pick, don't customize)
     └── checklist.md      ← quality checklist (P0 / P1 / P2 / P3 tiers)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - 📐 **横向左右翻页**:键盘 ← → / 滚轮 / 触屏滑动 / 底部圆点 / ESC 索引
 - 🎨 **5 套主题色预设**:墨水经典 / 靛蓝瓷 / 森林墨 / 牛皮纸 / 沙丘
 - 🧩 **10 种页面布局**:开场封面、章节幕封、数据大字报、左文右图、图片网格、Pipeline、悬念问题、大引用、Before/After 对比、图文混排
+- 🖼 **图片规划而非生图**:逐页判断是否需要图片,输出 prompt / 角色 / 比例 / 文件名 / 路径 / 动效,用户补图后再验收
+- ◫ **缺图占位**:HTML 中图片路径未找到时自动显示半透明空缺层,方便按清单补齐素材
 - 📄 **单文件 HTML**:不需要构建、不需要服务器,浏览器直接打开
 
 ## 适合 / 不适合
@@ -61,12 +63,12 @@ git clone https://github.com/op7418/guizang-ppt-skill.git ~/.claude/skills/guiza
 
 Skill 本身是结构化的 6 步工作流,Claude 会逐步引导:
 
-1. **需求澄清** — 6 问清单:受众、时长、素材、图片、主题色、硬约束
-2. **拷贝模板** — `assets/template.html` → 项目目录,改 `<title>`,换主题色
-3. **填充内容** — 从 10 种 layout 骨架里挑、粘、改文案(先做类名预检 + 主题节奏规划)
-4. **自检** — 对照 `references/checklist.md`,P0 级问题必须全过
-5. **预览** — 浏览器直接打开
-6. **迭代** — inline style 改字号/高度/间距
+1. **需求澄清** — 6 问清单:受众、时长、素材、图片、主题色、硬约束;如果用户没准备图片,先确认是预留补图空缺还是做无图版
+2. **图片与动效规划** — 每页写 `visual_intent` / `motion_level`;仅在需要补图时输出图片需求清单,不调用生图 API
+3. **拷贝模板** — `assets/template.html` → 项目目录,改 `<title>`,换主题色
+4. **填充内容** — 从 10 种 layout 骨架里挑、粘、改文案;仅在用户选择预留补图时保留占位
+5. **自检与图片验收** — 对照 `references/checklist.md`,检查缺失、比例、命名、风格、内容关联和阅读遮挡
+6. **预览 / 迭代** — 浏览器直接打开,inline style 改字号/高度/间距
 
 详细说明见 [`SKILL.md`](./SKILL.md)。
 
@@ -80,6 +82,7 @@ guizang-ppt-skill/
 │   └── template.html     ← 完整可运行的种子 HTML(CSS + WebGL + 翻页 JS 全配好)
 └── references/
     ├── components.md     ← 组件手册(字体、色、网格、图标、callout、stat、pipeline)
+    ├── image-workflow.md ← 图片规划与验收(prompt、角色、比例、缺图占位)
     ├── layouts.md        ← 10 种页面布局骨架(可直接粘贴)
     ├── themes.md         ← 5 套主题色预设(只能选不能自定义)
     └── checklist.md      ← 质量检查清单(P0 / P1 / P2 / P3 分级)

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,6 +17,16 @@ description: 生成"电子杂志 × 电子墨水"风格的横向翻页网页 PPT
 - **主题平滑插值**：翻到 hero 页时颜色和 shader 柔顺过渡
 - **翻页入场动效**（Motion One 驱动,5 种 recipe 自动匹配布局,本地 + CDN 双保险,离线可用）
 
+同时,这个 skill 会把图片当成可规划、可验收的内容资产来处理:
+
+- 判断每一页是否需要图片,以及需要几张图
+- 为背景图、主图、辅助图、装饰图、证据截图等分配角色和层级
+- 为每张图写 prompt、比例、文件名、放置路径和 HTML placement
+- 在用户尚未放入图片时,在 HTML 上显示半透明缺图占位
+- 用户补齐图片后,检查缺失、比例、命名、风格一致性、内容关联性和阅读遮挡
+
+**硬约束**:不要直接调用任何生图 API,不要真正生成图片。只做 prompt、图片规格、路径、占位、动效规划和后续检查。
+
 这个 skill 的美学不是"商务 PPT"，也不是"消费互联网 UI"——它像 *Monocle* 杂志贴上了代码后的样子。
 
 ## 何时使用
@@ -47,7 +57,7 @@ description: 生成"电子杂志 × 电子墨水"风格的横向翻页网页 PPT
 | 1 | **受众是谁?分享场景?**(行业内部 / 商业发布 / demo day / 私享会) | 决定语言风格和深度 |
 | 2 | **分享时长?** | 15 分钟 ≈ 10 页,30 分钟 ≈ 20 页,45 分钟 ≈ 25-30 页 |
 | 3 | **有没有原始素材?**(文档 / 数据 / 旧 PPT / 文章链接) | 有素材就基于素材,没有就帮他搭 |
-| 4 | **有没有图片?放在哪?** | 详见下方"图片约定" |
+| 4 | **有没有图片?放在哪?如果还没准备图片,要不要预留后续补图空缺?** | 决定 `image_mode`,详见下方"图片模式选择" |
 | 5 | **想要哪套主题色?** | 见 `references/themes.md`,5 套预设挑一 |
 | 6 | **有没有硬约束?**(必须包含 XX 数据 / 不能出现 YY) | 避免返工 |
 
@@ -67,24 +77,146 @@ description: 生成"电子杂志 × 电子墨水"风格的横向翻页网页 PPT
 
 大纲建议保存为 `项目记录.md` 或 `大纲-v1.md`,便于后续迭代。
 
+#### 图片模式选择(构建大纲时必问)
+
+如果用户没有准备图片,不要默认规划图片占位。必须先问:
+
+> 你现在没有准备图片的话,这份 PPT 要采用哪种图片策略?
+> 1. **预留补图空缺**:我会判断哪些页面值得放图,输出 prompt / 比例 / 文件名 / 路径,HTML 里先显示半透明缺图占位,等你后面把图片找齐再检查。
+> 2. **无图版**:不添加图片,不生成图片需求清单,改用大标题、数据、引用、流程和排版节奏完成表达。
+
+根据用户选择记录 `image_mode`:
+
+| image_mode | 适用 | 后续行为 |
+|---|---|---|
+| `provided` | 用户已有图片 | 按真实图片路径规划和检查 |
+| `placeholder` | 用户没图,但希望后面补图 | 输出图片需求清单,HTML 保留缺图占位 |
+| `text_only` | 用户没图,也不想后面补图 | 不添加图片,优先选无图布局或把图文布局改成纯排版 |
+
+没有得到这个选择前,不要进入 Step 1.5。若用户说"你看着办",默认选 `placeholder`,但要明确告诉用户会生成的是**补图空缺**,不是图片本身。
+
 #### 图片约定(告知用户)
 
 在动手前向用户说清:
 
 - **文件夹位置**:`项目/XXX/ppt/images/` 下(和 `index.html` 同级)
-- **命名规范**:`{页号}-{语义}.{ext}`,例如 `01-cover.jpg` / `03-figma.jpg` / `05-dashboard.png`
+- **命名规范**:`{页号}-{角色}-{语义}.{ext}`,例如 `01-bg-cover.jpg` / `03-main-figma.jpg` / `05-deco-arrow.png`
   - 页号补零便于排序
+  - 角色用英文短词:`bg` 背景图 / `main` 主图 / `support` 辅助图 / `deco` 装饰图 / `proof` 证据截图 / `portrait` 人物 / `logo` 标识
   - 语义用英文,短、具体、和内容对应
 - **规格建议**:
   - 单张 ≥ 1600px 宽(避免大屏模糊)
   - JPG 用于照片/截图,PNG 用于透明 UI/图表
   - 总大小控制在 10MB 内(影响翻页流畅度)
 - **如何替换**:保持**同名覆盖**最稳(HTML 里不用改路径);如果文件名变了,记得全局搜 `images/旧名` 改成新名
-- **没图怎么办**:和用户对齐,可以先用占位色块生成结构,等图片后期补;但要告知 layout 4/5/10 等图文混排页没图就没法验证视觉效果
+- **没图怎么办**:先询问图片模式。如果用户选 `placeholder`,不要调用任何生图 API,也不要真的生成图片,只规划 prompt / 比例 / 文件名 / 放置路径,把 HTML 做成缺图占位状态;如果用户选 `text_only`,就不添加图片,改用纯排版方案。
+
+### Step 1.5 · 图片与动效规划（**生成 HTML 前必做**）
+
+本 skill 的新工作流是**先确定 `image_mode`,再判断每页是否需要图片,最后生成 PPT 骨架**。不要等 HTML 写完后才临时塞图。
+
+如果 `image_mode=text_only`,仍然要写每页 `visual_intent` 和 `motion_level`,但图片需求清单应标记为"无图版,不需要图片",并避免使用依赖图片成立的 Layout 4 / 5 / 10。可以用 Layout 3 / 6 / 7 / 8 / 9 或纯文字变体替代。
+
+#### 1.5.1 每页视觉意图
+
+为每页写一条 `visual_intent`,说明这一页希望观众看到什么、记住什么。它不是文案复述,而是视觉任务:
+
+```markdown
+| 页 | layout | visual_intent | motion_level |
+|---|---|---|---|
+| 01 | Cover | 建立冷静、克制、带技术感的开场气质 | M |
+| 05 | Image Grid | 用多平台截图证明传播规模,让证据自己说话 | L |
+```
+
+#### 1.5.2 动效等级
+
+每页必须有 `motion_level`:
+
+| 等级 | 用法 | 规则 |
+|---|---|---|
+| `S` | 静态或近静态 | 内容密集、截图多、需要读清楚 |
+| `L` | 轻动效 | 默认值;标题、正文、图片顺序淡入 |
+| `M` | 中等动效 | hero / 转场 / 观点页,可用更慢 stagger |
+| `H` | 强动效 | 只给关键转折页;整份 deck 不超过 10-15% |
+
+每个可见元素都要写 `animation`:如 `fade-up` / `fade-left` / `fade-right` / `line-reveal` / `step-reveal` / `none`。落到 HTML 时对应 `data-anim` / `data-animate`:
+
+- `fade-up` → `data-anim`
+- `fade-left` → `data-anim="left"`
+- `fade-right` → `data-anim="right"`
+- `line-reveal` → section `data-animate="quote"` + 元素 `data-anim="line"`
+- `step-reveal` → section `data-animate="pipeline"` + 元素 `data-anim="step"`
+- `none` → 不加 `data-anim`
+
+#### 1.5.3 图片需求清单
+
+当 `image_mode=provided` 或 `placeholder` 时,逐页判断是否需要图。支持一页多图,也支持不同图片角色。只规划,不生成。
+
+如果 `image_mode=placeholder`,必须向用户返回这张表,让用户按表找图并放到 `images/`:
+
+```markdown
+| 页 | image_id | role | prompt | ratio | filename | path | placement | animation | required |
+|---|---|---|---|---|---|---|---|---|---|
+| 01 | 01-bg-cover | bg | 抽象电子墨水流体背景,低对比,杂志封面气质 | 16:9 | 01-bg-cover.jpg | images/01-bg-cover.jpg | hero 背景,弱化到 20% | none | optional |
+| 03 | 03-main-product | main | 产品界面截图,顶部导航完整,浅色背景,可读 | 16:10 | 03-main-product.png | images/03-main-product.png | 右列主图 | fade-right | required |
+| 05 | 05-proof-weibo | proof | 微博账号数据截图,顶部和数字完整 | fixed 26vh | 05-proof-weibo.png | images/05-proof-weibo.png | 3x2 网格第 1 张 | fade-up | required |
+```
+
+字段要求:
+
+- `role`:必须是 `bg` / `main` / `support` / `deco` / `proof` / `portrait` / `logo` 之一。
+- `prompt`:描述图片内容、风格、构图、禁止项;不要写"生成一张图"这种执行指令。
+- `ratio`:只用标准值 `16:9` / `16:10` / `4:3` / `3:2` / `3:4` / `1:1` / `fixed 26vh`。
+- `filename`:必须与 `path` 最后一段一致,页号补零,英文小写,用连字符。
+- `placement`:写清在页面的位置和层级,如"背景层,文字下方,透明度 18%"、"右列主图"、"标题旁装饰"。
+- `required`:正文证据图、截图、人物照片通常是 required;纯装饰图和背景图可 optional。
+
+如果 `image_mode=text_only`,不要输出假图片需求,改输出:
+
+```markdown
+图片策略: text_only
+本 deck 不添加图片。以下页面原本可用图片增强,但已改为纯排版表达:
+| 页 | 原可用图片 | 替代方案 |
+|---|---|---|
+| 03 | 产品界面截图 | 改用 3 个关键指标 + 一句 quote |
+```
+
+#### 1.5.4 图片层级
+
+按层级规划图片,避免图片抢字:
+
+| 层级 | 用途 | HTML / CSS 建议 |
+|---|---|---|
+| `background` | hero 背景、氛围图 | 放在 slide 内第一个视觉元素,低透明度,不要压过文字 |
+| `content` | 主图、截图、人物、证据 | 用 `.frame-img`,必须有 caption 和 alt |
+| `decoration` | 纹理、箭头、局部形状 | 面积小、低对比,不承载核心信息 |
+
+背景图和装饰图必须满足:即使删除,页面文案仍然完整;如果影响阅读,宁可不用。
+
+#### 1.5.5 HTML 缺图占位
+
+如果图片文件还不存在,仍然把 HTML 路径写好,并给 `<figure>` 增加图片元数据。模板会在图片加载失败时自动绘制半透明缺图层:
+
+```html
+<figure
+  class="frame-img"
+  style="aspect-ratio:16/10; max-height:56vh"
+  data-image-id="03-main-product"
+  data-role="main"
+  data-ratio="16:10"
+  data-prompt="产品界面截图,顶部导航完整,浅色背景,可读"
+  data-missing-label="03-main-product · images/03-main-product.png"
+  data-anim="right">
+  <img src="images/03-main-product.png" alt="产品界面截图">
+  <figcaption class="img-cap">Product · Interface Proof</figcaption>
+</figure>
+```
+
+不要为了消除 broken image 而删除 `<img>`。缺图状态本身就是给用户补素材的提示。
 
 ### Step 2 · 拷贝模板
 
-从 `assets/template.html` 拷贝一份到目标位置（通常是 `项目/XXX/ppt/index.html`），同时在同级建一个 `images/` 文件夹准备接图片。
+从 `assets/template.html` 拷贝一份到目标位置（通常是 `项目/XXX/ppt/index.html`），同时在同级建一个 `images/` 文件夹准备接图片。若已经完成 Step 1.5,把图片需求清单另存为 `image-plan.md` 或写进项目记录,方便用户逐项补图。
 
 ```bash
 mkdir -p "项目/XXX/ppt/images"
@@ -127,6 +259,12 @@ cp "<SKILL_ROOT>/assets/template.html" "项目/XXX/ppt/index.html"
 - 不要混搭(例如 ink 取墨水经典、paper 取沙丘)——会彻底违和
 
 ### Step 3 · 填充内容
+
+先基于 Step 1.5 的 `visual_intent`、`motion_level`、图片需求清单写 slide,再挑布局。每一页都要能回答三个问题:
+
+1. 这一页是否需要图片?如果需要,需要几张?
+2. 每张图片的角色是什么:背景、主图、辅助图、装饰图、证据图、人物、logo?
+3. 图片和文字谁是主角?图片是否会影响阅读?
 
 #### 3.0 · 预检:类名必须在 template.html 里有定义（**最重要**）
 
@@ -205,6 +343,33 @@ cp "<SKILL_ROOT>/assets/template.html" "项目/XXX/ppt/index.html"
 6. **用 Lucide,不用 emoji**
 7. **标题用衬线,正文用非衬线,元数据用等宽**
 
+#### 4.1 · 用户补图后的图片验收
+
+当用户把图片放入 `images/` 后,必须进行一次图片专项检查。不要只看文件是否存在。
+
+检查项:
+
+| 项 | 怎么查 | 不通过时怎么处理 |
+|---|---|---|
+| 缺失 | 对照 `image-plan.md` / HTML 中 `images/...` 路径,确认文件存在 | 保留缺图占位,告诉用户缺哪些文件 |
+| 比例 | 读取图片尺寸,和 `data-ratio` / 规划比例比较 | 建议裁切到标准比例,不要改成原图奇葩比例 |
+| 命名 | 文件名是否 `{页号}-{角色}-{语义}.{ext}` | 要求重命名或同步更新 HTML 路径 |
+| 风格一致性 | 是否同一套摄影/截图/插画语言,明暗和颗粒感是否一致 | 退回风格突兀的图,或降低为装饰/删除 |
+| 内容关联性 | 图片是否直接支撑本页 `visual_intent` | 无关图不要硬放,宁可用纯排版 |
+| 阅读影响 | 图片是否压住标题、降低对比、抢走主文注意力 | 降低透明度、移到装饰层、缩小或删掉 |
+| 裁切 | 顶部/左右是否完整,截图标题栏是否被切 | 调整 `object-position` 或换裁切版本 |
+
+可用检查输出格式:
+
+```markdown
+图片验收结果:
+- 通过: 8/10
+- 缺失: `images/05-proof-wechat.png`, `images/09-deco-map.png`
+- 比例需调整: `images/03-main-product.png` 当前 1240x900,建议裁成 16:10
+- 风格风险: 第 7 页人物图偏商业棚拍,和电子墨水杂志风不一致
+- 阅读风险: 第 1 页背景图中心高亮压住标题,建议透明度降到 12-16%
+```
+
 ### Step 5 · 本地预览
 
 直接在浏览器打开 `index.html` 就行。macOS 下：
@@ -231,6 +396,7 @@ guizang-ppt-skill/
 │   └── motion.min.js     ← Motion One 本地副本（离线兜底,约 64KB）
 └── references/
     ├── components.md     ← 组件手册（字体、色、网格、图标、callout、stat、pipeline、动效...）
+    ├── image-workflow.md ← 图片规划与验收（prompt、角色、比例、缺图占位、补图检查）
     ├── layouts.md        ← 10 种页面布局骨架（可直接粘贴,含动效标记）
     ├── themes.md         ← 5 套主题色预设（只能选不能自定义）
     └── checklist.md      ← 质量检查清单（P0/P1/P2/P3 分级）
@@ -239,10 +405,11 @@ guizang-ppt-skill/
 **加载顺序建议**：
 1. 先读完 `SKILL.md`(这个文件)了解整体
 2. Step 1 需求澄清完成后,读 `themes.md` 帮用户选定一套主题色
-3. **动手前 Read `assets/template.html` 的 `<style>` 块**——这是类名的唯一来源,缺类会导致整页样式崩
-4. 读 `layouts.md` 挑布局(顶部有 Pre-flight 类名清单、主题节奏规划、动效 recipe 决策树)
-5. 细节调整时读 `components.md` 查组件(含 Motion 动效系统章节)
-6. 生成后读 `checklist.md` 自检(顶部 P0-0 规则强制预检 + 动效自检块)
+3. 读 `image-workflow.md` 生成每页 `visual_intent`、`motion_level` 和图片需求清单
+4. **动手前 Read `assets/template.html` 的 `<style>` 块**——这是类名的唯一来源,缺类会导致整页样式崩
+5. 读 `layouts.md` 挑布局(顶部有 Pre-flight 类名清单、主题节奏规划、动效 recipe 决策树)
+6. 细节调整时读 `components.md` 查组件(含 Motion 动效系统章节)
+7. 生成后读 `checklist.md` 自检(顶部 P0-0 规则强制预检 + 图片验收 + 动效自检块)
 
 **动效相关**:模板已把 Motion One 的加载和 5 种 recipe 逻辑全部内嵌到 `template.html` 底部的 module script。你不需要改 JS,只需要按 `layouts.md` 的骨架在 HTML 里加 `data-anim` / `data-animate` 即可。离线演示靠 `assets/motion.min.js`,断网时自动降级为"无动画但内容可读"。
 

--- a/assets/template.html
+++ b/assets/template.html
@@ -166,6 +166,40 @@
   .frame-img{overflow:hidden;position:relative;background:rgba(0,0,0,.04);box-sizing:border-box;width:100%;border-radius:4px}
   .slide.dark .frame-img{background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.12)}
   .frame-img > img{width:100%;height:100%;object-fit:cover;object-position:top center;display:block}
+  .frame-img.is-missing,
+  .img-slot.is-missing{
+    background:
+      linear-gradient(135deg,rgba(var(--ink-rgb),.06),rgba(var(--ink-rgb),.015)),
+      repeating-linear-gradient(135deg,rgba(127,127,127,.18) 0 1px,transparent 1px 12px);
+    border:1px dashed rgba(127,127,127,.45);
+    box-shadow:inset 0 0 0 999px rgba(255,255,255,.06);
+  }
+  .slide.dark .frame-img.is-missing,
+  .slide.dark .img-slot.is-missing{
+    background:
+      linear-gradient(135deg,rgba(var(--paper-rgb),.08),rgba(var(--paper-rgb),.02)),
+      repeating-linear-gradient(135deg,rgba(255,255,255,.14) 0 1px,transparent 1px 12px);
+    box-shadow:inset 0 0 0 999px rgba(0,0,0,.10);
+  }
+  .frame-img.is-missing > img{opacity:0}
+  .frame-img.is-missing::after,
+  .img-slot.is-missing::after{
+    content:attr(data-missing-label);
+    position:absolute;
+    inset:0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    padding:2vh 2vw;
+    text-align:center;
+    font-family:var(--mono);
+    font-size:10px;
+    line-height:1.7;
+    letter-spacing:.18em;
+    text-transform:uppercase;
+    opacity:.58;
+    pointer-events:none;
+  }
   .frame-cap{display:flex;justify-content:space-between;align-items:baseline;gap:1vw;margin-top:.8vh;font-family:var(--mono);font-size:10px;letter-spacing:.22em;text-transform:uppercase;opacity:.72}
   .frame-cap .pf{font-family:var(--serif-zh);font-weight:600;font-size:max(13px,1vw);letter-spacing:.04em;text-transform:none;opacity:.94}
   .frame-cap .nb{font-family:var(--serif-en);font-style:italic;font-size:max(15px,1.2vw);letter-spacing:.02em;text-transform:none;opacity:.88}
@@ -565,6 +599,20 @@ const deck=document.getElementById('deck');
 const slides=deck.querySelectorAll('.slide');
 const nav=document.getElementById('nav');
 let idx=0,total=slides.length,lock=false;
+
+// 图片缺失检查:用户尚未放入图片时,自动在对应 frame 绘制半透明空缺层。
+document.querySelectorAll('.frame-img > img').forEach(img=>{
+  const frame=img.closest('.frame-img');
+  const markMissing=()=>{
+    const label=frame?.dataset.missingLabel || img.dataset.missingLabel || img.getAttribute('alt') || img.getAttribute('src') || 'Missing Image';
+    if(frame){
+      frame.classList.add('is-missing');
+      frame.dataset.missingLabel='MISSING · '+label;
+    }
+  };
+  img.addEventListener('error',markMissing);
+  if(img.complete && img.naturalWidth===0) markMissing();
+});
 
 // 关键：矫正 deck 宽度为 total * 100vw，否则翻页会错位
 deck.style.width=(total*100)+'vw';

--- a/references/image-workflow.md
+++ b/references/image-workflow.md
@@ -1,0 +1,143 @@
+# 图片规划与验收（Image Workflow）
+
+这个 skill 不调用生图 API,也不真正生成图片。它只负责判断每页是否需要图片、写清 prompt 与规格、在 HTML 中放好路径和缺图占位,并在用户补图后检查质量。
+
+在构建大纲时,如果用户没有准备图片,必须先确认图片策略:
+
+| image_mode | 含义 | 后续行为 |
+|---|---|---|
+| `provided` | 用户已经有图片 | 使用真实路径,检查比例/命名/风格 |
+| `placeholder` | 用户没有图片,但希望后面补图 | 输出图片需求清单,HTML 显示半透明缺图占位 |
+| `text_only` | 用户没有图片,也不需要补图 | 不输出图片需求,不在 HTML 中添加图片占位 |
+
+若用户没有明确选择,先问清楚。用户说"你看着办"时,可默认 `placeholder`,但必须说明这只是补图空缺,不是生成图片。
+
+---
+
+## 1. 每页规划字段
+
+每页都要有:
+
+| 字段 | 说明 | 示例 |
+|---|---|---|
+| `visual_intent` | 这一页的视觉任务 | 用一张产品截图证明工具已经可用,不是概念 |
+| `motion_level` | `S` / `L` / `M` / `H` | `L` |
+| `images` | 本页需要的图片数组,可为空 | 见下方 |
+| `elements.animation` | 每个主要元素的动效 | `title: fade-up`, `image: fade-right` |
+
+`image_mode=text_only` 时,`images` 应为空,并用纯排版替代图文页。
+
+页面规划示例:
+
+```yaml
+slide: 03
+layout: left-text-right-image
+visual_intent: 用真实界面截图建立可信度,让"已经做出来了"成为第一感受
+motion_level: L
+elements:
+  kicker:
+    animation: fade-up
+  title:
+    animation: fade-up
+  lead:
+    animation: fade-up
+  main_image:
+    animation: fade-right
+images:
+  - image_id: 03-main-product
+    role: main
+    prompt: 产品界面截图,浅色背景,顶部导航完整,关键数据可读,不要透视变形
+    ratio: 16:10
+    filename: 03-main-product.png
+    path: images/03-main-product.png
+    placement: 右列主图,content 层,caption 标注产品名
+    required: true
+```
+
+---
+
+## 2. 图片角色
+
+| role | 用途 | 注意 |
+|---|---|---|
+| `bg` | 背景图 / 氛围图 | 必须低对比,不能影响阅读 |
+| `main` | 本页主图 | 需要 caption 和 alt,承载核心证据 |
+| `support` | 辅助解释图 | 面积小于主图,不要抢标题 |
+| `deco` | 装饰图 / 纹理 / 局部符号 | 删除后页面仍应完整 |
+| `proof` | 证据截图 / 数据截图 | 顶部和关键数字必须完整 |
+| `portrait` | 人物照片 | 眼睛、面部不能被裁,风格要克制 |
+| `logo` | 品牌标识 | 用 PNG/SVG,留足安全边距 |
+
+一页可以多图,但每张都必须有独立 `image_id`、`role`、`prompt`、`ratio`、`filename`、`path`、`placement`、`animation`。
+
+---
+
+## 3. 比例与尺寸
+
+只使用标准比例:
+
+| 场景 | ratio |
+|---|---|
+| hero 背景 | `16:9` |
+| 左文右图主图 | `16:10` / `4:3` |
+| 图文混排辅助图 | `3:2` / `3:4` / `1:1` |
+| 人物头像或 logo 容器 | `1:1` |
+| 多截图网格 | `fixed 26vh` |
+
+不要把原图尺寸直接写进 `aspect-ratio`,例如 `2592/1798`。
+
+---
+
+## 4. HTML 标记
+
+图片未到位时也写真实路径,让模板自动显示缺图占位:
+
+```html
+<figure
+  class="frame-img"
+  style="aspect-ratio:16/10; max-height:56vh"
+  data-image-id="03-main-product"
+  data-role="main"
+  data-ratio="16:10"
+  data-prompt="产品界面截图,浅色背景,顶部导航完整,关键数据可读,不要透视变形"
+  data-missing-label="03-main-product · images/03-main-product.png"
+  data-anim="right">
+  <img src="images/03-main-product.png" alt="产品界面截图">
+  <figcaption class="img-cap">Product · Interface Proof</figcaption>
+</figure>
+```
+
+如果是纯占位草稿,可以用:
+
+```html
+<div
+  class="img-slot is-missing r-4x3"
+  data-image-id="04-support-map"
+  data-role="support"
+  data-ratio="4:3"
+  data-missing-label="MISSING · 04-support-map · images/04-support-map.png">
+  <span class="plus">+</span>
+  <span class="label">04-support-map</span>
+</div>
+```
+
+优先使用 `<figure class="frame-img"> + <img>`。`img-slot` 只用于早期草稿或装饰层占位。
+
+---
+
+## 5. 最终验收输出
+
+用户补图后,检查并返回:
+
+```markdown
+图片验收结果:
+- 文件完整性:
+- 比例:
+- 命名:
+- 风格一致性:
+- 内容关联性:
+- 阅读影响:
+- 需要用户处理:
+```
+
+不合格图片不要硬塞进 deck。图片没有帮助时,让版式自己成立。


### PR DESCRIPTION
增加图片规划工作流：在生成 PPT 前判断每页是否需要图片，支持无图版/预留补图空缺，输出图片 prompt、比例、路径和动效规划；模板会对缺失图片显示半透明占位，且不调用任何生图 API。