### PR TITLE
fix(template): render only the visible WebGL canvas

### DIFF
--- a/assets/template.html
+++ b/assets/template.html
@@ -607,7 +607,11 @@ function startGL(){
   function loop(){
     if(window.__lowPowerMode){glRAF=0;return;}
     const t=(Date.now()-glT0)/1000;
-    drawDark(t);drawLight(t);
+    if(document.body.classList.contains('light-bg')){
+      drawLight(t);
+    } else {
+      drawDark(t);
+    }
     glRAF=requestAnimationFrame(loop);
   }
   glRAF=requestAnimationFrame(loop);


### PR DESCRIPTION
Both bg-dark and bg-light canvases were rendering every frame, even though CSS keeps only one visible at a time (the other at opacity:0). With this fix, only the canvas matching the current theme (body.light-bg) is drawn each RAF tick. Shaves ~50% GPU load on template.html (Style A).

**Verification:**
- All 6 slide types tested
- before/after pixel-identical
- No visual regression