### PR TITLE
Add .claude-plugin/plugin.json for Claude Code marketplace support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "guizang-ppt-skill",
+  "description": "生成横向翻页网页 PPT（单 HTML 文件），含 WebGL 背景、章节幕封、数据大字报、图片网格等模板。Magazine-style & Swiss International Style web slides.",
+  "version": "1.1.0",
+  "keywords": [
+    "ppt",
+    "slides",
+    "presentation",
+    "magazine",
+    "swiss-style",
+    "webgl",
+    "html"
+  ],
+  "author": {
+    "name": "歸藏",
+    "url": "https://github.com/op7418"
+  }
+}


### PR DESCRIPTION
This PR adds `.claude-plugin/plugin.json` so that `guizang-ppt-skill` can be published to the Claude Code plugin marketplace.

     What this enables
- Users can install this skill via the Claude Code marketplace (no more manual `git clone`)
- Automatic updates when new versions are released
- The skill will appear with proper metadata (name, version, keywords) in CC Switch