### PR TITLE
fix: dark-slide card-fill color cascade + generation pitfall checks (§3.3 §3.4 + checklist 0-G/H/I)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -387,6 +387,20 @@ cp "<SKILL_ROOT>/assets/template-swiss.html" "项目/XXX/ppt/index.html"
 
 组件细节(字体、颜色、网格、图标、callout、stat-card 等)在 `references/components.md`。
 
+#### 3.3 · HTML 实体规范（跨平台必做）
+
+**HTML 内容里的特殊标点必须用实体，禁止直接写原字符**（Windows GBK 编码会把 `·` `→` 等 UTF-8 字符损坏成乱码）。常用速查：`&middot;` `&mdash;` `&ndash;` `&rarr;` `&larr;` `&yen;` `&amp;` `&times;`。用 `Write` 工具写入文件，不要用 PowerShell `Set-Content`。
+
+**⚠️ JS 字符串例外**：`element.textContent = '&larr;'` 会原样输出 `&larr;` 文字。JS 里直接写 Unicode：`← → · — ¥`，或改用 `element.innerHTML`。
+
+验收见 checklist `0-G`。
+
+#### 3.4 · motion 代码两个必须保留的守卫
+
+改写或简化 motion 代码时（如制作 standalone 离线包），必须保留：① `playSlide` 开头的低功耗模式提前返回（`if(window.__lowPowerMode){ revealStatic(slide); return; }`）；② recipe 执行前把所有 `[data-anim]` 容器批量设为 `opacity:1`，再由 WAAPI 按需覆盖。缺少任一，部分页面内容在静态模式下将不可见。
+
+验收见 checklist `0-I`。
+
 ### Step 4 · 对照检查清单自检
 
 生成完一定要打开 `references/checklist.md`，逐项对照。里面总结了**真实迭代过程中踩过的所有坑**，P0 级别的问题（emoji、图片撑破、标题换行、字体分工）必须全部通过。

--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -609,6 +609,11 @@
   .card-ink .t-meta,.card-ink .t-cat{color:rgba(255,255,255,.6)}
   .card-accent{background:var(--accent);border:0;color:var(--accent-on)}
   .card-accent .t-meta,.card-accent .t-cat{color:var(--accent-on)}
+  /* Bug fix: dark slide color cascade into light-bg card-fill — reverse override */
+  .slide.dark .card-fill{color:var(--text-primary)}
+  .slide.dark .card-fill h3,.slide.dark .card-fill .t-h-prod{color:var(--text-primary)}
+  .slide.dark .card-fill p,.slide.dark .card-fill .t-body-sm{color:var(--text-secondary)}
+  .slide.dark .card-fill .t-meta,.slide.dark .card-fill .t-helper{color:var(--text-helper)}
 
   /* ============ 动效 (与原模板一致) ============ */
   [data-anim]{opacity:1}

--- a/references/checklist.md
+++ b/references/checklist.md
@@ -237,6 +237,42 @@ node <SKILL_ROOT>/scripts/validate-swiss-deck.mjs path/to/index.html
 - 对照原始 PPT 时以实际画面为准;raw CSS helper 只能辅助,不能替代视觉判断
 - 判断问题来源:版式选错 / 必选组件缺失 / 可选组件滥用 / 间距和安全区问题
 - 通用版式(S03/S08/S11/S19)可多用;数据专用(S06/S07/S20/S21/S22)必须有真实数据或案例;结构专用(S14/S15/S17)必须有闭环、矩阵或层级关系
+### 0-G. 特殊字符编码安全
+
+**现象**：页面里 `·`、`→`、`—`、`¥` 等符号显示为乱码（`路`、`鈥?` 等），或 JS 提示文字里出现 `&larr;` 原始字串。
+
+**根因**：① HTML 内容直接写了原始 Unicode 符号，经 PowerShell GBK 管道写入后损坏；② JS 字符串里错用了 HTML 实体（`textContent` 不解析实体）。
+
+**做法**：
+- HTML 内容用实体：`&middot;` `&mdash;` `&ndash;` `&rarr;` `&larr;` `&yen;` `&amp;` `&times;`
+- JS 字符串直接写 Unicode：`← → · — ¥`，或改 `element.innerHTML`（仅硬编码字符串）
+- 用 `Write` 工具写文件，不用 PowerShell `Set-Content`
+
+**自检**：浏览器打开，逐页确认特殊符号显示正常；检查动效提示栏（右下角 hint）无 `&` 开头的字面量。
+
+### 0-H. 暗色页（`.slide.dark`）内 `.card-fill` 文字穿色
+
+**现象**：暗色页里的白底卡片（`.card-fill`）内文字变成白色，白字白底不可见；或 `.t-h-prod`、`h3` 等标题类在白色背景上仍显示白色。
+
+**根因**：`.slide.dark .t-h-prod`（三类选择器高特异度）覆盖了 `.card-fill` 内的文字颜色，导致白底卡片上文字跟随暗色主题变白。
+
+**做法**：`template-swiss.html` 已在 `.card-accent` 规则后添加反覆盖修复；如手写自定义样式，确保 `.slide.dark .card-fill` 的文字色回归 `var(--text-primary)`。
+
+**自检**：目视翻到所有 `.slide.dark` 页，找其中含 `.card-fill`（白底）的页面，确认卡片内文字清晰可读（深色），不是白字白底。
+
+### 0-I. 静态模式下每页内容完整可见
+
+**现象**：默认打开或按 `B` 关闭动效后，部分页面主体内容不可见——卡片区域、时间轴节点、三栏内容整块消失，只剩标题。
+
+**根因A**：`[data-anim]` 容器元素被 CSS `body.motion-ready [data-anim]{opacity:0}` 归零，但 recipe 只给其**子元素**加了动画，容器永远不透明 → 子元素不论如何动都看不见。**根因B**：低功耗模式下 recipe 仍执行，WAAPI 动画在 `opacity:0` 起始帧被取消，元素卡住；无 `data-anim` 属性的 `.dot`、`.label` 不受 CSS 兜底保护。
+
+**做法（模板标准实现）**：① `playSlide` 开头：`if(window.__lowPowerMode){ revealStatic(slide); return; }`；② recipe 执行前批量 `slide.querySelectorAll('[data-anim]').forEach(el=>{ el.style.opacity='1'; el.style.transform='none'; })`。
+
+**自检**：
+1. 打开 deck，**不按 B**，逐页翻看，确认每页内容全部可见（不依赖动效）
+2. 按 `B` 切到静态模式，重新从第 1 页翻到最后，再次确认全部内容可见
+3. 重点检查含 `data-animate="four-cards/three-forces/why-now/split-statement/timeline-walk"` 的页面
+
 ---
 
 ### 0. 生成前必须通过的类名校验(最重要)
@@ -563,6 +599,11 @@ JS 会动态算总页数并扩展底部翻页圆点，但 `.chrome` 里的 `XX /
   □ Before/After 对比页 `<section>` 带 `data-animate="directional"`,左右列标 left/right
   □ Pipeline 页 `<section>` 带 `data-animate="pipeline"`,每 step 标 data-anim="step"
   □ `grep -c 'data-anim' index.html` 数量 ≥ 页数 × 3(平均每页 3 个以上标记)
+  □ 【0-I】不按 B / 按 B 关闭动效后，逐页翻看，每页内容全部可见（无整块消失）
+
+编码与样式
+  □ 【0-G】页面内无乱码（·→—¥ 正常显示），动效 hint 栏无 &larr; 等字面量
+  □ 【0-H】暗色页（.slide.dark）内含 .card-fill 白底卡片的，文字为深色可读
 ```
 
 全勾完，才是合格的 PPT。


### PR DESCRIPTION
## Changes

### Bug fix — `assets/template-swiss.html`

`.slide.dark .card-fill` inherits `color: var(--paper)` (white) from the dark slide rule, making text invisible inside light-background cards placed on dark slides. Adds explicit overrides to restore dark text inside `.card-fill` when nested under `.slide.dark`.

### Docs — `SKILL.md` §3.3 & §3.4

Two generation-time pitfalls surfaced during real usage on Windows:

**§3.3 HTML entity rule**: Special punctuation (`·` `→` `—` `¥` etc.) must be written as HTML entities in HTML content. Windows file writers (PowerShell `Set-Content`, GBK locale) corrupt raw UTF-8 multi-byte sequences. Companion warning: JS `textContent` does NOT parse entities — use Unicode literals there instead.

**§3.4 motion guards**: When customising or simplifying the motion module, two guards must survive:
- (a) low-power early-return at the top of `playSlide` — `if(window.__lowPowerMode){ revealStatic(slide); return; }`
- (b) pre-reveal of all `[data-anim]` containers to `opacity:1` before any WAAPI animation runs

Missing either leaves content invisible in static / low-power mode.

### Docs — `references/checklist.md`

Three new P0 items to catch the above at review time:
- `0-G` encoding safety (GBK corruption + JS entity literals)
- `0-H` dark-slide `.card-fill` text readability (visual check)
- `0-I` static-mode page completeness (all slides visible with motion off)