### PR TITLE
personal: Windows encoding rules, card-fill fix, standalone builder, …

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -184,6 +184,25 @@ Swiss validation:
 node scripts/validate-swiss-deck.mjs path/to/index.html
 ```
 
+## Standalone Packaging
+
+The generated deck normally requires Google Fonts CDN and a local `assets/` folder. To share the deck as a **fully self-contained file** that works offline and without any folder structure, run:
+
+```bash
+# default: index.html → index_standalone.html (same directory)
+py scripts/build-standalone.py index.html
+
+# explicit output path
+py scripts/build-standalone.py input.html output.html
+
+# skip font embedding (faster, requires network for fonts)
+py scripts/build-standalone.py --no-fonts input.html
+```
+
+The script embeds Google Fonts Inter + JetBrains Mono (Latin subsets only, ~184KB), `motion.min.js` (base64 data: URI), and Lucide icons (inline SVG). Output is ~1.8MB and opens directly in any browser — ideal for sending over messaging apps or email.
+
+**Requirements**: Python 3.8+, no third-party packages; needs internet access once to download fonts (~5 seconds), then fully offline.
+
 ## Codex Image Flow
 
 In Codex, after the first deck draft is ready, the agent can ask whether the user wants generated visuals. Once confirmed, choose an image type or style. Common types include:
@@ -244,9 +263,11 @@ guizang-ppt-skill/
 ├── assets/
 │   ├── template.html         ← Style A editorial magazine template
 │   ├── template-swiss.html   ← Style B Swiss template
+│   ├── motion.min.js         ← Motion One local copy (offline fallback, ~64KB)
 │   └── screenshot-backgrounds/ ← bundled WebP screenshot backgrounds: 5 style-a / 4 style-b
 ├── scripts/
-│   └── validate-swiss-deck.mjs ← Swiss layout validator
+│   ├── validate-swiss-deck.mjs ← Swiss layout validator
+│   └── build-standalone.py     ← offline packager: embeds fonts/motion/icons into a single shareable HTML
 └── references/
     ├── components.md     ← component catalog (type, color, grid, icons, callout, stat, pipeline)
     ├── layouts.md        ← 10 layout skeletons (paste-ready)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,25 @@ Skill 本身是结构化工作流,Agent 会逐步引导:
 node scripts/validate-swiss-deck.mjs path/to/index.html
 ```
 
+## 独立文件打包
+
+生成的 deck 默认依赖 Google Fonts CDN 和本地 `assets/` 目录。如果需要**转发给他人在没有网络或本地文件夹的环境下查看**，可以用打包脚本生成完全独立的单文件 HTML：
+
+```bash
+# 默认：index.html → index_standalone.html（同目录）
+py scripts/build-standalone.py index.html
+
+# 指定输出路径
+py scripts/build-standalone.py input.html output.html
+
+# 跳过字体内嵌（更快，但需要网络加载字体）
+py scripts/build-standalone.py --no-fonts input.html
+```
+
+脚本会自动内嵌：Google Fonts Inter + JetBrains Mono（仅 Latin 子集，约 184KB）、`motion.min.js`（base64 data: URI）、Lucide 图标（内联 SVG）。输出单文件约 1.8MB，浏览器离线直接打开，可发送微信/邮件/Telegram 附件。
+
+**依赖**：Python 3.8+，无需安装第三方包；需要打包时联网下载字体（约 5 秒），之后可完全离线使用。
+
 ## Codex 配图能力
 
 在 Codex 环境中,完成 deck 初稿后可以主动询问用户是否需要生成配图。用户确认后,再询问图片类型或风格,常用类型包括:
@@ -245,9 +264,11 @@ guizang-ppt-skill/
 ├── assets/
 │   ├── template.html         ← Style A 电子杂志风模板
 │   ├── template-swiss.html   ← Style B 瑞士国际主义模板
+│   ├── motion.min.js         ← Motion One 本地副本(离线兜底,约 64KB)
 │   └── screenshot-backgrounds/ ← 截图美化内置背景(WebP):style-a 5 套 / style-b 4 套
 ├── scripts/
-│   └── validate-swiss-deck.mjs ← 瑞士风版式校验器
+│   ├── validate-swiss-deck.mjs ← 瑞士风版式校验器
+│   └── build-standalone.py     ← 离线打包:内嵌字体/motion/图标，输出单文件可转发 HTML
 └── references/
     ├── components.md     ← 组件手册(字体、色、网格、图标、callout、stat、pipeline)
     ├── layouts.md        ← 10 种页面布局骨架(可直接粘贴)

--- a/SKILL.md
+++ b/SKILL.md
@@ -387,6 +387,20 @@ cp "<SKILL_ROOT>/assets/template-swiss.html" "项目/XXX/ppt/index.html"
 
 组件细节(字体、颜色、网格、图标、callout、stat-card 等)在 `references/components.md`。
 
+#### 3.3 · HTML 实体规范（跨平台必做）
+
+**HTML 内容里的特殊标点必须用实体，禁止直接写原字符**（Windows GBK 编码会把 `·` `→` 等 UTF-8 字符损坏成乱码）。常用速查：`&middot;` `&mdash;` `&ndash;` `&rarr;` `&larr;` `&yen;` `&amp;` `&times;`。用 `Write` 工具写入文件，不要用 PowerShell `Set-Content`。
+
+**⚠️ JS 字符串例外**：`element.textContent = '&larr;'` 会原样输出 `&larr;` 文字。JS 里直接写 Unicode：`← → · — ¥`，或改用 `element.innerHTML`。
+
+验收见 checklist `0-G`。
+
+#### 3.4 · motion 代码两个必须保留的守卫
+
+改写或简化 motion 代码时（如制作 standalone 离线包），必须保留：① `playSlide` 开头的低功耗模式提前返回（`if(window.__lowPowerMode){ revealStatic(slide); return; }`）；② recipe 执行前把所有 `[data-anim]` 容器批量设为 `opacity:1`，再由 WAAPI 按需覆盖。缺少任一，部分页面内容在静态模式下将不可见。
+
+验收见 checklist `0-I`。
+
 ### Step 4 · 对照检查清单自检
 
 生成完一定要打开 `references/checklist.md`，逐项对照。里面总结了**真实迭代过程中踩过的所有坑**，P0 级别的问题（emoji、图片撑破、标题换行、字体分工）必须全部通过。
@@ -439,6 +453,16 @@ cp "<SKILL_ROOT>/assets/template-swiss.html" "项目/XXX/ppt/index.html"
 23. **组件角色要正确**——S15/S16 图片格需要 caption 信息锚点;S22 的 KPI/说明是必选;数据专用版式必须有真实数据,不能靠文案硬填
 24. **通用/非通用版式要分清**——S03/S08/S11/S19 较通用;S06/S07/S20/S21/S22 是数据/案例专用;S14/S15/S17 是结构专用
 
+### Step 4.5 · （可选）打包为独立离线文件
+
+如果 deck 需要**转发给他人在没有网络或本地服务器的环境下查看**，运行打包脚本：
+
+```bash
+py scripts/build-standalone.py index.html output_standalone.html
+```
+
+脚本会自动内嵌 Google Fonts（仅 Latin 子集）、`motion.min.js`（data: URI）和 Lucide 图标（内联 SVG），输出单文件约 1.8MB，浏览器离线可直接打开。详见脚本顶部 docstring。
+
 ### Step 5 · 本地预览
 
 直接在浏览器打开 `index.html` 就行。macOS 下：
@@ -466,7 +490,8 @@ guizang-ppt-skill/
 │   ├── screenshot-backgrounds/ ← 截图美化内置背景(WebP):style-a 5 套 / style-b 4 套
 │   └── motion.min.js         ← Motion One 本地副本（离线兜底,约 64KB,共用）
 ├── scripts/
-│   └── validate-swiss-deck.mjs ← 风格 B 静态校验:登记版式、图片槽位、SVG 文本、标题对齐
+│   ├── validate-swiss-deck.mjs ← 风格 B 静态校验:登记版式、图片槽位、SVG 文本、标题对齐
+│   └── build-standalone.py     ← 离线打包:内嵌字体/motion/Lucide，输出单文件可转发 HTML
 └── references/
     ├── components.md         ← 组件手册（字体、色、网格、图标、callout、stat、pipeline、动效... 风格 A 适用）
     ├── layouts.md            ← 风格 A · 10 种页面布局骨架（可直接粘贴,含动效标记）

--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -609,6 +609,11 @@
   .card-ink .t-meta,.card-ink .t-cat{color:rgba(255,255,255,.6)}
   .card-accent{background:var(--accent);border:0;color:var(--accent-on)}
   .card-accent .t-meta,.card-accent .t-cat{color:var(--accent-on)}
+  /* Bug fix: dark slide color cascade into light-bg card-fill — reverse override */
+  .slide.dark .card-fill{color:var(--text-primary)}
+  .slide.dark .card-fill h3,.slide.dark .card-fill .t-h-prod{color:var(--text-primary)}
+  .slide.dark .card-fill p,.slide.dark .card-fill .t-body-sm{color:var(--text-secondary)}
+  .slide.dark .card-fill .t-meta,.slide.dark .card-fill .t-helper{color:var(--text-helper)}
 
   /* ============ 动效 (与原模板一致) ============ */
   [data-anim]{opacity:1}

--- a/references/checklist.md
+++ b/references/checklist.md
@@ -237,6 +237,42 @@ node <SKILL_ROOT>/scripts/validate-swiss-deck.mjs path/to/index.html
 - 对照原始 PPT 时以实际画面为准;raw CSS helper 只能辅助,不能替代视觉判断
 - 判断问题来源:版式选错 / 必选组件缺失 / 可选组件滥用 / 间距和安全区问题
 - 通用版式(S03/S08/S11/S19)可多用;数据专用(S06/S07/S20/S21/S22)必须有真实数据或案例;结构专用(S14/S15/S17)必须有闭环、矩阵或层级关系
+### 0-G. 特殊字符编码安全
+
+**现象**：页面里 `·`、`→`、`—`、`¥` 等符号显示为乱码（`路`、`鈥?` 等），或 JS 提示文字里出现 `&larr;` 原始字串。
+
+**根因**：① HTML 内容直接写了原始 Unicode 符号，经 PowerShell GBK 管道写入后损坏；② JS 字符串里错用了 HTML 实体（`textContent` 不解析实体）。
+
+**做法**：
+- HTML 内容用实体：`&middot;` `&mdash;` `&ndash;` `&rarr;` `&larr;` `&yen;` `&amp;` `&times;`
+- JS 字符串直接写 Unicode：`← → · — ¥`，或改 `element.innerHTML`（仅硬编码字符串）
+- 用 `Write` 工具写文件，不用 PowerShell `Set-Content`
+
+**自检**：浏览器打开，逐页确认特殊符号显示正常；检查动效提示栏（右下角 hint）无 `&` 开头的字面量。
+
+### 0-H. 暗色页（`.slide.dark`）内 `.card-fill` 文字穿色
+
+**现象**：暗色页里的白底卡片（`.card-fill`）内文字变成白色，白字白底不可见；或 `.t-h-prod`、`h3` 等标题类在白色背景上仍显示白色。
+
+**根因**：`.slide.dark .t-h-prod`（三类选择器高特异度）覆盖了 `.card-fill` 内的文字颜色，导致白底卡片上文字跟随暗色主题变白。
+
+**做法**：`template-swiss.html` 已在 `.card-accent` 规则后添加反覆盖修复；如手写自定义样式，确保 `.slide.dark .card-fill` 的文字色回归 `var(--text-primary)`。
+
+**自检**：目视翻到所有 `.slide.dark` 页，找其中含 `.card-fill`（白底）的页面，确认卡片内文字清晰可读（深色），不是白字白底。
+
+### 0-I. 静态模式下每页内容完整可见
+
+**现象**：默认打开或按 `B` 关闭动效后，部分页面主体内容不可见——卡片区域、时间轴节点、三栏内容整块消失，只剩标题。
+
+**根因A**：`[data-anim]` 容器元素被 CSS `body.motion-ready [data-anim]{opacity:0}` 归零，但 recipe 只给其**子元素**加了动画，容器永远不透明 → 子元素不论如何动都看不见。**根因B**：低功耗模式下 recipe 仍执行，WAAPI 动画在 `opacity:0` 起始帧被取消，元素卡住；无 `data-anim` 属性的 `.dot`、`.label` 不受 CSS 兜底保护。
+
+**做法（模板标准实现）**：① `playSlide` 开头：`if(window.__lowPowerMode){ revealStatic(slide); return; }`；② recipe 执行前批量 `slide.querySelectorAll('[data-anim]').forEach(el=>{ el.style.opacity='1'; el.style.transform='none'; })`。
+
+**自检**：
+1. 打开 deck，**不按 B**，逐页翻看，确认每页内容全部可见（不依赖动效）
+2. 按 `B` 切到静态模式，重新从第 1 页翻到最后，再次确认全部内容可见
+3. 重点检查含 `data-animate="four-cards/three-forces/why-now/split-statement/timeline-walk"` 的页面
+
 ---
 
 ### 0. 生成前必须通过的类名校验(最重要)
@@ -563,6 +599,11 @@ JS 会动态算总页数并扩展底部翻页圆点，但 `.chrome` 里的 `XX /
   □ Before/After 对比页 `<section>` 带 `data-animate="directional"`,左右列标 left/right
   □ Pipeline 页 `<section>` 带 `data-animate="pipeline"`,每 step 标 data-anim="step"
   □ `grep -c 'data-anim' index.html` 数量 ≥ 页数 × 3(平均每页 3 个以上标记)
+  □ 【0-I】不按 B / 按 B 关闭动效后，逐页翻看，每页内容全部可见（无整块消失）
+
+编码与样式
+  □ 【0-G】页面内无乱码（·→—¥ 正常显示），动效 hint 栏无 &larr; 等字面量
+  □ 【0-H】暗色页（.slide.dark）内含 .card-fill 白底卡片的，文字为深色可读
 ```
 
 全勾完，才是合格的 PPT。

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -1,0 +1,243 @@
+"""
+build-standalone.py — Bundle a guizang Swiss PPT HTML into a fully self-contained offline file.
+
+Embeds:
+  - Google Fonts (Inter + JetBrains Mono, Latin subset only: U+0000-024F)
+  - motion.min.js (as a data: URI for ES module import)
+  - Lucide icons (inline SVG for the 4 icons used in Swiss layouts)
+
+Usage:
+  python build-standalone.py                        # default: index.html -> standalone.html (same dir)
+  python build-standalone.py input.html             # -> input_standalone.html
+  python build-standalone.py input.html output.html # explicit output path
+  python build-standalone.py --no-fonts input.html  # skip font embedding (faster, needs network)
+
+Requirements: Python 3.8+, no external packages.
+"""
+
+import argparse
+import base64
+import os
+import re
+import ssl
+import sys
+import urllib.request
+
+UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+FONTS_URL = (
+    'https://fonts.googleapis.com/css2?'
+    'family=Inter:wght@200;300;400;500;600;700;800;900'
+    '&family=JetBrains+Mono:wght@300;400;500;600&display=swap'
+)
+
+# Lucide icons used in Swiss layouts — extend this dict if new icons are needed
+LUCIDE_ICONS = {
+    'trending-up': (
+        '<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"></polyline>'
+        '<polyline points="16 7 22 7 22 13"></polyline>'
+    ),
+    'calendar': (
+        '<rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>'
+        '<line x1="16" y1="2" x2="16" y2="6"></line>'
+        '<line x1="8" y1="2" x2="8" y2="6"></line>'
+        '<line x1="3" y1="10" x2="21" y2="10"></line>'
+    ),
+    'landmark': (
+        '<line x1="3" y1="22" x2="21" y2="22"></line>'
+        '<line x1="6" y1="18" x2="6" y2="11"></line>'
+        '<line x1="10" y1="18" x2="10" y2="11"></line>'
+        '<line x1="14" y1="18" x2="14" y2="11"></line>'
+        '<line x1="18" y1="18" x2="18" y2="11"></line>'
+        '<polygon points="12 2 20 7 4 7"></polygon>'
+    ),
+    'bar-chart-2': (
+        '<line x1="18" y1="20" x2="18" y2="10"></line>'
+        '<line x1="12" y1="20" x2="12" y2="4"></line>'
+        '<line x1="6" y1="20" x2="6" y2="14"></line>'
+    ),
+    'briefcase': (
+        '<rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect>'
+        '<path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>'
+    ),
+    'award': (
+        '<circle cx="12" cy="8" r="6"></circle>'
+        '<path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11"></path>'
+    ),
+    'zap': (
+        '<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>'
+    ),
+    'target': (
+        '<circle cx="12" cy="12" r="10"></circle>'
+        '<circle cx="12" cy="12" r="6"></circle>'
+        '<circle cx="12" cy="12" r="2"></circle>'
+    ),
+}
+
+
+def fetch(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={'User-Agent': UA})
+    try:
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as r:
+            return r.read()
+    except Exception:
+        ctx2 = ssl._create_unverified_context()
+        with urllib.request.urlopen(req, context=ctx2, timeout=30) as r:
+            return r.read()
+
+
+def embed_fonts() -> str:
+    """Download Google Fonts CSS, keep only Latin subsets, embed woff2 as data URIs."""
+    print('Fetching Google Fonts CSS...')
+    raw_css = fetch(FONTS_URL).decode('utf-8')
+
+    blocks = re.findall(r'@font-face\s*\{[^}]+\}', raw_css, re.DOTALL)
+    latin_blocks = [
+        b for b in blocks
+        if 'U+0000-00FF' in b or 'U+0100-024F' in b or 'U+0100-02BA' in b
+    ]
+    print(f'  @font-face blocks: {len(latin_blocks)} / {len(blocks)} (Latin only)')
+
+    css = '\n'.join(latin_blocks)
+
+    woff2_urls = list(dict.fromkeys(
+        re.findall(r'url\((https://fonts\.gstatic\.com/[^)]+\.woff2)\)', css)
+    ))
+    print(f'  Unique woff2 files: {len(woff2_urls)}')
+
+    total_raw = 0
+    for i, url in enumerate(woff2_urls):
+        label = url.split('/')[-1][:40]
+        print(f'  [{i+1}/{len(woff2_urls)}] {label}', end=' ... ', flush=True)
+        data = fetch(url)
+        total_raw += len(data)
+        b64 = base64.b64encode(data).decode('ascii')
+        css = css.replace(url, f'data:font/woff2;base64,{b64}')
+        print(f'{len(data)//1024}KB')
+
+    print(f'  Fonts total: {total_raw//1024}KB raw -> {len(css)//1024}KB CSS')
+    return css
+
+
+def embed_motion(input_dir: str) -> str:
+    """Read motion.min.js from assets/ sibling of input file, return base64 data URI."""
+    motion_path = os.path.join(input_dir, 'assets', 'motion.min.js')
+    if not os.path.exists(motion_path):
+        print(f'  WARNING: motion.min.js not found at {motion_path} — skipping motion embed')
+        return ''
+    with open(motion_path, 'rb') as f:
+        data = f.read()
+    b64 = base64.b64encode(data).decode('ascii')
+    print(f'  motion.min.js: {len(data)//1024}KB')
+    return f'data:text/javascript;base64,{b64}'
+
+
+def build_lucide_inline() -> str:
+    icons_js = ',\n    '.join(
+        f"'{name}':'{svg}'" for name, svg in LUCIDE_ICONS.items()
+    )
+    return f"""<script>
+(function(){{
+  var ICONS={{
+    {icons_js}
+  }};
+  document.addEventListener('DOMContentLoaded',function(){{
+    document.querySelectorAll('i[data-lucide]').forEach(function(el){{
+      var name=el.getAttribute('data-lucide');
+      if(!ICONS[name])return;
+      var svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
+      svg.setAttribute('xmlns','http://www.w3.org/2000/svg');
+      svg.setAttribute('viewBox','0 0 24 24');
+      svg.setAttribute('fill','none');
+      svg.setAttribute('stroke','currentColor');
+      svg.setAttribute('stroke-width','2');
+      svg.setAttribute('stroke-linecap','round');
+      svg.setAttribute('stroke-linejoin','round');
+      if(el.className)svg.className=el.className;
+      svg.innerHTML=ICONS[name];
+      el.parentNode.replaceChild(svg,el);
+    }});
+  }});
+}})();
+</script>"""
+
+
+def assemble(input_path: str, output_path: str, embed_fonts_flag: bool = True) -> None:
+    input_dir = os.path.dirname(os.path.abspath(input_path))
+
+    print(f'Reading {input_path}...')
+    with open(input_path, 'r', encoding='utf-8') as f:
+        html = f.read()
+    print(f'  Source: {len(html)//1024}KB')
+
+    # ── 1. Remove Google Fonts link tags ────────────────────────────────────
+    html = re.sub(r'<link rel="preconnect"[^>]+>\s*\n?', '', html)
+    html = re.sub(r'<link [^>]*fonts\.googleapis\.com[^>]*>\s*\n?', '', html)
+
+    # ── 2. Embed fonts ───────────────────────────────────────────────────────
+    if embed_fonts_flag:
+        fonts_css = embed_fonts()
+        font_style_tag = f'<style>\n{fonts_css}\n</style>\n'
+        html = html.replace('<style>', font_style_tag + '<style>', 1)
+    else:
+        print('  Skipping font embed (--no-fonts)')
+
+    # ── 3. Embed motion.min.js as data: URI ─────────────────────────────────
+    motion_uri = embed_motion(input_dir)
+    if motion_uri:
+        html = html.replace(
+            "await import('./assets/motion.min.js')",
+            f"await import('{motion_uri}')"
+        )
+
+    # ── 4. Replace Lucide CDN with inline icon creator ───────────────────────
+    lucide_inline = build_lucide_inline()
+    html = re.sub(
+        r'<script src="https://unpkg\.com/lucide[^"]*"[^>]*></script>\s*\n?',
+        '', html
+    )
+    html = re.sub(
+        r'<script>if\(typeof lucide[^<]+</script>\s*\n?',
+        '', html
+    )
+    html = html.replace('</body>', lucide_inline + '\n</body>')
+
+    # ── 5. Write output as pure UTF-8 (binary mode avoids BOM on Windows) ───
+    with open(output_path, 'wb') as f:
+        f.write(html.encode('utf-8'))
+
+    size_kb = os.path.getsize(output_path) // 1024
+    print(f'\nOutput: {output_path}')
+    print(f'  Size: {size_kb}KB ({size_kb/1024:.1f}MB)')
+    print('Done.')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Bundle a guizang Swiss PPT HTML into a fully offline standalone file.'
+    )
+    parser.add_argument('input', nargs='?', default='index.html',
+                        help='Input HTML file (default: index.html)')
+    parser.add_argument('output', nargs='?', default=None,
+                        help='Output HTML file (default: <input-stem>_standalone.html)')
+    parser.add_argument('--no-fonts', action='store_true',
+                        help='Skip Google Fonts embedding (deck will require network for fonts)')
+    args = parser.parse_args()
+
+    input_path = os.path.abspath(args.input)
+    if not os.path.exists(input_path):
+        print(f'Error: input file not found: {input_path}', file=sys.stderr)
+        sys.exit(1)
+
+    if args.output:
+        output_path = os.path.abspath(args.output)
+    else:
+        stem, _ = os.path.splitext(input_path)
+        output_path = stem + '_standalone.html'
+
+    assemble(input_path, output_path, embed_fonts_flag=not args.no_fonts)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…checklist P0 items

- assets/template-swiss.html: fix .slide.dark .card-fill text color cascade
- SKILL.md: §3.3 HTML-entity encoding rule, §3.4 motion container+low-power guards, Step 4.5 standalone packaging workflow
- references/checklist.md: P0 items 0-G (encoding), 0-H (dark card-fill), 0-I (static visibility)
- README.md / README.en.md: build-standalone.py docs and directory tree
- scripts/build-standalone.py: offline single-file packaging script (fonts+motion+icons)

## Summary

- 

## What Changed

- 

## Visual QA

Please attach screenshots for visual changes.

- [ ] Checked at least one dense text slide
- [ ] Checked at least one image slide
- [ ] Checked navigation / ESC overview / low-power mode when relevant

## Validation

- [ ] `node scripts/validate-swiss-deck.mjs path/to/index.html`
- [ ] Manual browser review

## Notes

Any tradeoffs, limitations, or follow-up work:
