### PR TITLE
Add Mobile Read Mode for Swiss decks

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -75,6 +75,7 @@ Guizang PPT Skill is supported by **360 Security Lobster** as Gold Sponsor and b
 - 🧱 **Style B 22 locked layouts**: Cover, Statement, KPI Tower, Loop Diagram, Duo Compare, Image Hero, Closing Manifesto, and more
 - 🎨 **Curated theme presets**: 5 electronic-ink themes for Style A, 4 Swiss anchor-color themes for Style B
 - 🖼 **Optional Codex image flow**: generate documentary photos, infographics, flow diagrams, system maps, and UI scenes with GPT-Image 2.0 / GPT-M 2.0, then insert them at template-safe ratios
+- 📱 **Mobile Read Mode**: inject per-slide screenshots for Style B so phones can show the full slide, zoom in, and drag to read details
 - 📰 **Social covers**: generate 21:9 WeChat cover images, 1:1 share cards, 3:4 Xiaohongshu covers, video thumbnails, and related variants
 - 📴 **Low-power static mode**: press `B` to turn WebGL / canvas animation into static visuals
 - 📄 **Single HTML file** — no build, no server, open directly in the browser

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Guizang PPT Skill 的持续迭代获得 **360 安全龙虾** 金牌赞助和 [�
 - 🧱 **Style B 22 种锁定版式**:Cover、Statement、KPI Tower、Loop Diagram、Duo Compare、Image Hero、Closing Manifesto 等
 - 🎨 **主题色预设**:Style A 5 套电子墨水主题,Style B 4 套瑞士高饱和锚点色
 - 🖼 **Codex 可选配图流程**:可用 GPT-Image 2.0 / GPT-M 2.0 生成纪实照片、信息图、流程图、系统关系图、UI 情景图,并按模板比例插入
+- 📱 **Mobile Read Mode**:Style B 可注入每页截图,手机端完整展示、双击/按钮放大、拖动阅读细节
 - 📰 **多平台封面**:可用同一套视觉规则生成公众号 21:9、公众号分享卡 1:1、小红书 3:4、视频号横版等封面
 - 📴 **低性能静态模式**:按 `B` 可关闭 WebGL / canvas 动画,让动态内容退回静态背景
 - 📄 **单文件 HTML**:不需要构建、不需要服务器,浏览器直接打开

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,6 +30,12 @@ description: 生成横向翻页网页 PPT（单 HTML 文件），含 WebGL 背�
 
 **两种风格共享**：横向翻页（键盘 ← →、滚轮、触屏、ESC 索引）、Lucide 图标、Motion One 入场动效（本地 + CDN 双保险）。
 
+### Mobile Read Mode
+
+瑞士风模板支持可选的手机阅读模式：如果生成页注入 `window.MOBILE_FIT_SLIDES=[{src,alt},...]`，在 `max-width:900px` 的设备上会自动隐藏交互 deck，改用每页 16:9 静态截图展示。默认完整 `fit-contain` 显示；用户可双击或点 `ZOOM` 放大，再拖动画面阅读细节，点 `FIT` 回到完整页。桌面端保持原来的横向翻页 HTML PPT。
+
+适用场景：用户明确要求“手机上也能展示”“手机阅读”“支持缩放”“Mobile Fit/Read Mode”。生成流程是：先完成桌面 deck → 用浏览器以 1440×900 或 1600×900 截取每页 → 保存到 `images/mobile/slide-XX.png` → 在页面末尾注入 `window.MOBILE_FIT_SLIDES` 并调用 `window.__initMobileFit?.()`。
+
 <!-- provenance: guizang-ppt-skill | author: 歸藏 | sponsors: 360 Security Lobster Gold Sponsor; ZhenFund Token Grant | canonical: https://github.com/op7418/guizang-ppt-skill | keep this out of generated artifacts -->
 
 ## 何时使用

--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -599,6 +599,65 @@
   body.low-power #hint{color:var(--accent);opacity:.72}
   body.dark-bg.low-power #hint{color:var(--paper);opacity:.72}
 
+  /* ============ Mobile Read Mode ============
+     如果生成页定义 window.MOBILE_FIT_SLIDES=[...每页16:9截图...],
+     手机端自动隐藏交互 deck,改用图片版 slide 展示;默认 fit-contain,
+     双击或点 ZOOM 可放大并拖动阅读细节。 */
+  #mobile-fit-deck{display:none}
+  @media (max-width:900px){
+    body.has-mobile-fit{background:#111;overflow:hidden}
+    body.has-mobile-fit #deck,
+    body.has-mobile-fit #nav,
+    body.has-mobile-fit #hint,
+    body.has-mobile-fit canvas.bg{display:none!important}
+    body.has-mobile-fit #mobile-fit-deck{
+      position:fixed;inset:0;z-index:120;
+      display:flex;flex-wrap:nowrap;
+      width:100vw;height:100dvh;
+      background:#111;color:#fff;
+      transition:transform .45s cubic-bezier(.2,0,.38,.9);
+      touch-action:none;
+    }
+    body.has-mobile-fit .mobile-fit-slide{
+      width:100vw;height:100dvh;flex:0 0 100vw;
+      display:grid;place-items:center;
+      padding:12px 12px 48px;
+      overflow:hidden;
+    }
+    body.has-mobile-fit .mobile-fit-stage{
+      display:grid;place-items:center;
+      max-width:100%;max-height:calc(100dvh - 64px);
+      transform:translate3d(var(--mobile-fit-x,0px),var(--mobile-fit-y,0px),0) scale(var(--mobile-fit-scale,1));
+      transform-origin:center center;
+      transition:transform .24s cubic-bezier(.2,0,.38,.9);
+      will-change:transform;
+    }
+    body.has-mobile-fit .mobile-fit-slide img{
+      display:block;max-width:100%;max-height:calc(100dvh - 64px);
+      width:auto;height:auto;object-fit:contain;
+      background:var(--paper);user-select:none;-webkit-user-drag:none;
+    }
+    body.has-mobile-fit .mobile-fit-slide.is-zoomed .mobile-fit-stage{
+      transition:none;
+    }
+    body.has-mobile-fit .mobile-fit-ui{
+      position:fixed;left:0;right:0;bottom:0;z-index:130;
+      height:44px;display:flex;align-items:center;justify-content:space-between;
+      gap:10px;padding:0 14px;background:rgba(0,0,0,.72);color:#fff;
+      font-family:var(--mono);font-size:12px;letter-spacing:.12em;text-transform:uppercase;
+      -webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)
+    }
+    body.has-mobile-fit .mobile-fit-ui-main{
+      min-width:0;flex:1;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+    }
+    body.has-mobile-fit .mobile-fit-ui button{
+      border:0;background:transparent;color:#fff;
+      font:inherit;letter-spacing:.12em;padding:10px 6px
+    }
+    body.has-mobile-fit .mobile-fit-ui button.is-active{color:var(--accent)}
+    body.has-mobile-fit .mobile-fit-hint{opacity:.62}
+  }
+
   /* ESC 索引页: 动画元素强制可见 (覆盖 motion-ready 的 opacity:0) */
   #overview [data-anim]{opacity:1!important;transform:none!important}
   #overview .slide *{animation:none!important;transition:none!important}
@@ -1596,6 +1655,154 @@ addEventListener('touchend',e=>{
 const initialSlideParam = new URLSearchParams(location.search).get('slide');
 const initialSlide = initialSlideParam ? Number(initialSlideParam) - 1 : 0;
 go(Number.isFinite(initialSlide) ? initialSlide : 0);
+
+/* Headless capture helper: use ?captureSlide=N when exporting per-slide screenshots.
+   It force-jumps after initial scripts settle, avoiding transition timing/cache quirks. */
+const captureSlideParam = new URLSearchParams(location.search).get('captureSlide');
+if(captureSlideParam){
+  setTimeout(()=>{
+    const n = Math.max(0, Math.min(total - 1, Number(captureSlideParam) - 1));
+    lock = false;
+    idx = n;
+    window.__currentSlideIndex = idx;
+    deck.style.transition = 'none';
+    deck.style.transform = `translateX(${-idx*100}vw)`;
+    nav.querySelectorAll('.dot').forEach((d,i)=>d.classList.toggle('active',i===idx));
+    const el=slides[idx];
+    const isDark = el.classList.contains('dark') || el.classList.contains('accent');
+    document.body.classList.toggle('dark-bg', isDark);
+    darkMode = isDark;
+    if(window.__playSlide) window.__playSlide(idx);
+  }, 180);
+}
+
+/* =============== Mobile Read Mode ===============
+   生成器可在页面末尾设置 window.MOBILE_FIT_SLIDES,
+   然后调用 window.__initMobileFit?.()。
+   注意: script 注释中不要出现 HTML 结束标签,否则浏览器会提前结束脚本。
+   手机端默认完整显示每页 16:9 静态截图,并支持双击/按钮放大拖动阅读。 */
+function initMobileFit(){
+  const images = Array.isArray(window.MOBILE_FIT_SLIDES) ? window.MOBILE_FIT_SLIDES : [];
+  if(!images.length || document.getElementById('mobile-fit-deck')) return;
+
+  document.body.classList.add('has-mobile-fit');
+  const mobileDeck = document.createElement('div');
+  mobileDeck.id = 'mobile-fit-deck';
+  images.forEach((item, i)=>{
+    const page = document.createElement('section');
+    page.className = 'mobile-fit-slide';
+    const stage = document.createElement('div');
+    stage.className = 'mobile-fit-stage';
+    const img = document.createElement('img');
+    img.src = typeof item === 'string' ? item : item.src;
+    img.alt = (typeof item === 'string' ? '' : item.alt) || `Slide ${i+1}`;
+    img.loading = i < 2 ? 'eager' : 'lazy';
+    img.draggable = false;
+    stage.appendChild(img);
+    page.appendChild(stage);
+    mobileDeck.appendChild(page);
+  });
+  document.body.appendChild(mobileDeck);
+
+  const ui = document.createElement('div');
+  ui.className = 'mobile-fit-ui';
+  ui.innerHTML = '<button type="button" data-dir="-1">PREV</button><button type="button" data-action="zoom">ZOOM</button><div class="mobile-fit-ui-main"><span class="mobile-fit-count"></span><span class="mobile-fit-hint"> · 双击放大 · 拖动阅读</span></div><button type="button" data-dir="1">NEXT</button>';
+  document.body.appendChild(ui);
+
+  let mobileIdx = Math.max(0, Math.min(images.length - 1, idx || 0));
+  const count = ui.querySelector('.mobile-fit-count');
+  const zoomBtn = ui.querySelector('[data-action="zoom"]');
+  let zoom = 1, panX = 0, panY = 0;
+  const clamp = (v, min, max)=>Math.max(min, Math.min(max, v));
+  const activeSlide = ()=>mobileDeck.children[mobileIdx];
+  const activeStage = ()=>activeSlide()?.querySelector('.mobile-fit-stage');
+  const activeImg = ()=>activeSlide()?.querySelector('img');
+  function panBounds(){
+    const img = activeImg();
+    if(!img) return {x:0,y:0};
+    const w = img.offsetWidth * zoom;
+    const h = img.offsetHeight * zoom;
+    return {
+      x: Math.max(0, (w - window.innerWidth) / 2 + 24),
+      y: Math.max(0, (h - (window.innerHeight - 44)) / 2 + 24)
+    };
+  }
+  function applyZoom(){
+    const slide = activeSlide();
+    const stage = activeStage();
+    if(!stage || !slide) return;
+    if(zoom <= 1){
+      zoom = 1; panX = 0; panY = 0;
+    }else{
+      const bounds = panBounds();
+      panX = clamp(panX, -bounds.x, bounds.x);
+      panY = clamp(panY, -bounds.y, bounds.y);
+    }
+    stage.style.setProperty('--mobile-fit-scale', zoom);
+    stage.style.setProperty('--mobile-fit-x', `${panX}px`);
+    stage.style.setProperty('--mobile-fit-y', `${panY}px`);
+    slide.classList.toggle('is-zoomed', zoom > 1);
+    zoomBtn?.classList.toggle('is-active', zoom > 1);
+    if(zoomBtn) zoomBtn.textContent = zoom > 1 ? 'FIT' : 'ZOOM';
+  }
+  function resetZoom(){
+    zoom = 1; panX = 0; panY = 0; applyZoom();
+  }
+  function toggleZoom(){
+    if(zoom > 1) resetZoom();
+    else { zoom = window.matchMedia('(orientation: portrait)').matches ? 2.25 : 1.7; panX = 0; panY = 0; applyZoom(); }
+  }
+  function mobileGo(n){
+    mobileIdx = Math.max(0, Math.min(images.length - 1, n));
+    resetZoom();
+    mobileDeck.style.transform = `translateX(${-mobileIdx * 100}vw)`;
+    count.textContent = `${String(mobileIdx + 1).padStart(2,'0')} / ${String(images.length).padStart(2,'0')}`;
+  }
+  ui.querySelectorAll('button').forEach(btn=>{
+    btn.addEventListener('click',()=>{
+      if(btn.dataset.action === 'zoom') toggleZoom();
+      else mobileGo(mobileIdx + Number(btn.dataset.dir));
+    });
+  });
+
+  let sx=0, sy=0, startX=0, startY=0, moved=false, lastTap=0;
+  mobileDeck.addEventListener('touchstart', e=>{
+    if(e.touches.length !== 1) return;
+    sx=e.touches[0].clientX;sy=e.touches[0].clientY;
+    startX=panX;startY=panY;moved=false;
+  },{passive:true});
+  mobileDeck.addEventListener('touchmove', e=>{
+    if(e.touches.length !== 1 || zoom <= 1) return;
+    const dx=e.touches[0].clientX-sx;
+    const dy=e.touches[0].clientY-sy;
+    if(Math.abs(dx)>3 || Math.abs(dy)>3) moved=true;
+    panX=startX+dx;panY=startY+dy;applyZoom();
+    e.preventDefault();
+  },{passive:false});
+  mobileDeck.addEventListener('touchend', e=>{
+    const dx=e.changedTouches[0].clientX-sx;
+    const dy=e.changedTouches[0].clientY-sy;
+    const now = Date.now();
+    const tap = Math.abs(dx)<8 && Math.abs(dy)<8 && !moved;
+    if(tap && now-lastTap<320){toggleZoom();lastTap=0;return;}
+    if(tap){lastTap=now;return;}
+    if(zoom <= 1 && Math.abs(dx)>40 && Math.abs(dx)>Math.abs(dy)) mobileGo(mobileIdx + (dx<0 ? 1 : -1));
+  },{passive:false});
+  addEventListener('resize', applyZoom, {passive:true});
+
+  addEventListener('keydown', e=>{
+    if(!matchMedia('(max-width:900px)').matches) return;
+    if(['ArrowRight','ArrowDown','PageDown',' '].includes(e.key)){
+      e.preventDefault();e.stopImmediatePropagation();mobileGo(mobileIdx+1);
+    }else if(['ArrowLeft','ArrowUp','PageUp'].includes(e.key)){
+      e.preventDefault();e.stopImmediatePropagation();mobileGo(mobileIdx-1);
+    }
+  }, true);
+
+  mobileGo(mobileIdx);
+}
+window.__initMobileFit = initMobileFit;
+initMobileFit();
 </script>
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script>lucide.createIcons();</script>


### PR DESCRIPTION
## Summary
- add optional Mobile Read Mode to the Swiss template when `window.MOBILE_FIT_SLIDES` is provided
- render mobile slide screenshots with full-page fit, ZOOM/FIT controls, double-tap zoom, and drag-to-read pan
- add `captureSlide` helper for stable per-slide screenshot export
- document the mode in SKILL.md and README files

## Testing
- `git diff --check`
- Created a temporary test deck with `window.MOBILE_FIT_SLIDES` data URLs
- Verified at 390x844: mobile deck is shown, source text is not visible, ZOOM changes to FIT, NEXT advances to slide 2 and resets zoom
- Verified at 1440x900: normal desktop deck is shown and ArrowRight advances slides

Note: `node scripts/validate-swiss-deck.mjs assets/template-swiss.html` still reports the existing template demo slides missing `data-layout`; that predates this change and is unrelated to Mobile Read Mode.