### PR TITLE
feat: 添加 WYSIWYG 编辑面板（外置注入架构）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.backup
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+This is a **Claude Code Skill** — a structured workflow that AI agents follow to generate single-file HTML slide decks. It is not a traditional application with a build step, server, or test suite. The primary "user" of this repo is an AI agent reading `SKILL.md` and `references/` to produce `index.html` decks.
+
+## Architecture: two visual systems
+
+The skill provides two mutually exclusive visual styles. They share no CSS classes and cannot be mixed in one deck.
+
+| | Style A · Magazine | Style B · Swiss |
+|---|---|---|
+| Template seed | `assets/template.html` | `assets/template-swiss.html` |
+| Layouts | `references/layouts.md` (10 flexible layouts) | `references/layouts-swiss.md` (22 locked layouts S01–S22) |
+| Themes | `references/themes.md` (5 presets) | `references/themes-swiss.md` (4 accent-color presets) |
+| Lock file | none | `references/swiss-layout-lock.md` (hard constraints) |
+| Validator | none | `scripts/validate-swiss-deck.mjs` |
+| Typography | Serif titles (Noto Serif SC) + sans body | All sans-serif (Inter/Helvetica/Noto Sans SC), extreme weight contrast (200 for large, 400–600 for small) |
+| Aesthetic | Monocle-magazine, warm ink/paper, WebGL fluid backgrounds | Grid-based, single accent color, hairline rules, no gradients/shadows/rounded corners |
+| Icons | Lucide (CDN) | Lucide (CDN) |
+| Animation | Motion One (CDN + local fallback `assets/motion.min.js`) | Motion One (same fallback) + low-power mode (key `B`) |
+| Edit mode | WYSIWYG panel injected via `scripts/inject-edit-panel.mjs` after generation (key `E`): click-to-select, CSS property sliders, theme switch, download | Same (shared JS auto-detects style, CSS is per-style) |
+| Image backgrounds | `assets/screenshot-backgrounds/style-a/` (5 WebP) | `assets/screenshot-backgrounds/style-b/` (4 WebP) |
+
+## Key files
+
+```
+SKILL.md                    ← The skill definition. Contains the full 6-step workflow, design principles,
+                               component class lists, and common mistakes. This is the entry point for agents.
+assets/
+  template.html             ← Style A seed. Complete runnable HTML with CSS, WebGL shaders, nav JS.
+  template-swiss.html       ← Style B seed. Same structure but Swiss CSS grid system, ASCII canvas, etc.
+  motion.min.js             ← Motion One local copy (~64 KB) for offline animation fallback.
+  screenshot-backgrounds/   ← Pre-baked WebP backgrounds for screenshot framing (5 style-a + 4 style-b).
+scripts/
+  validate-swiss-deck.mjs   ← Node script that checks a Swiss deck HTML for: registered data-layout,
+                               missing image slots, SVG text, centered titles, experimental layouts.
+references/
+  checklist.md              ← Quality checklist (P0/P1/P2/P3), built from real iteration mistakes.
+  components.md             ← Component reference for Style A (typography, chrome, callout, stat, pipeline,
+                               figure, icons, motion recipes). Style B components are in layouts-swiss.md appendix.
+  layouts.md                ← 10 Style A page skeletons (copy-paste ready) + theme rhythm planning rules.
+  layouts-swiss.md          ← 22 Style B page skeletons (S01–S22) + experimental extensions.
+  swiss-layout-lock.md      ← Swiss hard constraints: registered layouts, golden source path, image slot rules.
+  swiss-map-component.md    ← S08 MapLibre extension: data contract, pin/line/card structure, interaction rules.
+  themes.md                 ← 5 Style A color presets (ink/paper variable blocks to paste into :root).
+  themes-swiss.md           ← 4 Style B color presets (accent/paper/ink/grey variable blocks).
+  image-prompts.md          ← GPT-M 2.0 image generation prompts, ratio selection, style rules per deck type.
+  screenshot-framing.md     ← CleanShot X-style screenshot adaptation: 7 semantic parameters, background mapping.
+```
+
+## Development workflow
+
+There is no build, no package manager, no test runner. Changes follow this pattern:
+
+1. **Template changes**: Edit `assets/template.html` or `assets/template-swiss.html` directly. These are standalone HTML files — open in a browser to verify. For Swiss template changes, keep the registered base CSS/JS intact; the golden source is the original reference PPT (path in `swiss-layout-lock.md`). When modifying template code, verify the WYSIWYG edit panel still works: press `E`, click elements, adjust properties, download.
+
+2. **Layout changes**: When adding a Style B layout, you must update four files in lockstep: `template-swiss.html` (CSS classes), `layouts-swiss.md` (skeleton docs), `swiss-layout-lock.md` (registration), and `validate-swiss-deck.mjs` (validation rules).
+
+3. **Document extraction**: Before generating a PPT from a user-provided document, extract structured content:
+   ```bash
+   node scripts/extract-doc.mjs path/to/document.docx --output path/to/content.md
+   ```
+   Supports `.docx` (via JSZip, auto-detects headings), `.md` (passthrough), and `.txt` (paragraph preservation). Outputs Markdown with YAML metadata header.
+
+4. **Swiss validation**: The only automated check in the repo:
+   ```bash
+   node scripts/validate-swiss-deck.mjs path/to/index.html
+   ```
+   Add `--allow-experimental` to suppress P23/P24 detection. This script parses HTML with regex (not a DOM parser) — it matches `<section class="slide">` blocks and checks `data-layout`, image slots, SVG text, and title alignment.
+
+4. **Theme changes**: Add new color presets only to `references/themes.md` or `references/themes-swiss.md`. Each preset is a `:root` variable block. Custom hex values from users must be rejected — only the curated presets are allowed.
+
+5. **New checklist items**: When you discover a bug pattern during deck generation, add it to `references/checklist.md` under the appropriate priority level (P0 = must-fix, P1 = rhythm, P2 = visual polish, P3 = operational).
+
+## Contribution constraints (from CONTRIBUTING.md)
+
+- Swiss template: do not invent new default body layouts without explicit discussion. Keep the registered layout system intact. Run the validator.
+- Template changes: verify at least one dense text slide, one image slide, navigation, ESC overview, and low-power mode (`B` key).
+- This skill is opinionated by design — constrained layout systems over unlimited customization, because constraints make AI-generated decks more reliable.
+- When in doubt, preserve existing visual rules and improve the workflow around them.
+
+## Agent workflow (how the skill is used at runtime)
+
+When invoked, the agent follows the 6-step pipeline in `SKILL.md`:
+
+1. **Clarify** — 7 questions: style (A/B), audience, duration, source material, images/screenshots, theme color, constraints
+2. **Copy template** — `cp assets/template*.html → project/index.html`, create `images/` dir, replace `[必填]` placeholders, apply theme variables
+3. **Fill content** — plan theme rhythm table, pick layouts from references, paste skeletons, replace text/images. Critical: must Read the template `<style>` block first to verify all CSS classes exist.
+4. **Self-check** — run Swiss validator (Style B only), then go through `checklist.md` P0 items
+5. **Preview** — open `index.html` in browser
+6. **Iterate** — adjust inline styles (90% of changes are `font-size`, `height`, `gap` tweaks). Remind the user they can press `E` in the browser to open the built-in WYSIWYG edit panel for quick self-service adjustments.
+
+Images go in `images/` next to `index.html`, named `{page}-{semantic}.{ext}`. In Style B, every local `<img>` must have `data-image-slot` attribute.
+
+## Naming and conventions
+
+- `<SKILL_ROOT>` in documentation refers to the root of this repository (e.g., `~/.claude/skills/guizang-ppt-skill`)
+- The term "Skill" (capital S) is used consistently — never mix Chinese/English translations
+- Style B layout IDs: `S01`–`S22` for body pages, `SWISS-COVER-ASCII` / `SWISS-CLOSING-ASCII` for cover/closing
+- Style B slides must have `data-layout="Sxx"` on the `<section>` element
+- Style A slides use `class="slide light"`, `class="slide dark"`, `class="slide hero light"`, or `class="slide hero dark"` — never just `hero` without a theme

--- a/SKILL.md
+++ b/SKILL.md
@@ -439,15 +439,23 @@ cp "<SKILL_ROOT>/assets/template-swiss.html" "项目/XXX/ppt/index.html"
 23. **组件角色要正确**——S15/S16 图片格需要 caption 信息锚点;S22 的 KPI/说明是必选;数据专用版式必须有真实数据,不能靠文案硬填
 24. **通用/非通用版式要分清**——S03/S08/S11/S19 较通用;S06/S07/S20/S21/S22 是数据/案例专用;S14/S15/S17 是结构专用
 
-### Step 5 · 本地预览
+### Step 5 · 注入编辑面板 + 本地预览
 
-直接在浏览器打开 `index.html` 就行。macOS 下：
+生成完成后，先注入 WYSIWYG 编辑面板（编辑面板代码存放在独立文件中，不在模板里，避免增加 agent 读模板的 token 开销）：
+
+```bash
+node "<SKILL_ROOT>/scripts/inject-edit-panel.mjs" "项目/XXX/ppt/index.html"
+```
+
+脚本会自动检测风格 A/B，注入对应的 CSS + 面板 HTML + JS。
+
+然后直接在浏览器打开 `index.html`：
 
 ```bash
 open "项目/XXX/ppt/index.html"
 ```
 
-不需要本地服务器。图片走相对路径 `images/xxx.png`。
+按 `E` 键或点击右下角 ✏️ 按钮即可进入编辑模式，点击页面元素实时调整 CSS 属性（margin、padding、字号、颜色等），修改满意后点「下载 HTML」导出。
 
 ### Step 6 · 迭代
 
@@ -462,11 +470,17 @@ guizang-ppt-skill/
 ├── SKILL.md                  ← 你正在读
 ├── assets/
 │   ├── template.html         ← 风格 A · 电子杂志风模板（种子文件）
-│   ├── template-swiss.html   ← 风格 B · 瑞士国际主义风模板（种子文件）
+│   ├── template-swiss.html   ← 风格 B · 瑞士国际主义风模板（种子文件,含注入标记）
+│   ├── edit-panel/           ← WYSIWYG 编辑面板资源(生成后注入,不在模板中)
+│   │   ├── style-a.css       ← 风格 A 面板样式
+│   │   ├── style-b.css       ← 风格 B 面板样式
+│   │   ├── panel.html        ← 共享面板 HTML 片段
+│   │   └── editor.js         ← 共享编辑逻辑(自动检测风格 A/B)
 │   ├── screenshot-backgrounds/ ← 截图美化内置背景(WebP):style-a 5 套 / style-b 4 套
 │   └── motion.min.js         ← Motion One 本地副本（离线兜底,约 64KB,共用）
 ├── scripts/
-│   └── validate-swiss-deck.mjs ← 风格 B 静态校验:登记版式、图片槽位、SVG 文本、标题对齐
+│   ├── validate-swiss-deck.mjs ← 风格 B 静态校验:登记版式、图片槽位、SVG 文本、标题对齐
+│   └── inject-edit-panel.mjs   ← WYSIWYG 编辑面板注入:自动检测风格,注入 CSS+HTML+JS
 └── references/
     ├── components.md         ← 组件手册（字体、色、网格、图标、callout、stat、pipeline、动效... 风格 A 适用）
     ├── layouts.md            ← 风格 A · 10 种页面布局骨架（可直接粘贴,含动效标记）
@@ -495,6 +509,7 @@ guizang-ppt-skill/
 6. 如果在 Codex 中生成配图,读 `image-prompts.md` 挑图片类型、比例和基础提示词;如果是用户原始截图,先读 `screenshot-framing.md`,优先使用 `assets/screenshot-backgrounds/` 的内置背景资产
 7. 细节调整时读 `components.md` 查组件(含 Motion 动效系统章节,主要服务风格 A;风格 B 的组件细节在 `layouts-swiss.md` 附录)
 8. 生成后先运行 `node scripts/validate-swiss-deck.mjs path/to/index.html`,再读 `checklist.md` 自检
+9. 注入 WYSIWYG 编辑面板:`node scripts/inject-edit-panel.mjs path/to/index.html`，注入后按 `E` 键即可在浏览器中可视化编辑
 
 **动效相关**:模板已把 Motion One 的加载和 recipe 逻辑内嵌到底部 module script。你不需要改 JS,只需要按 `layouts.md` / `layouts-swiss.md` 的骨架在 HTML 里加 `data-anim` / `data-animate` 即可。离线演示靠 `assets/motion.min.js`,断网时自动降级为"无动画但内容可读"。风格 B 模板必须保留 `B` 键低功耗模式:切换后停止 WebGL/ASCII canvas RAF,取消正在运行的 Web Animations,并把当前页内容直接 reveal 到静态最终态。
 

--- a/assets/edit-panel/editor.js
+++ b/assets/edit-panel/editor.js
@@ -1,0 +1,382 @@
+(function(){
+  'use strict';
+
+  // ============ 模板类型检测 ============
+  var csRoot = getComputedStyle(document.documentElement);
+  var isStyleA = !!csRoot.getPropertyValue('--ink-tint').trim(); // Magazine has --ink-tint, Swiss doesn't
+
+  // ============ 状态 ============
+  var editMode = false;
+  var selectedEl = null;
+  var editedStyles = new Map();
+  var root = document.documentElement;
+
+  // 存储原始 CSS 变量值
+  var rootVarNames = isStyleA
+    ? ['--ink','--ink-rgb','--paper','--paper-rgb','--paper-tint','--ink-tint']
+    : ['--accent','--accent-rgb','--accent-on','--accent-bright','--paper','--paper-rgb','--ink','--ink-rgb','--grey-1','--grey-2','--grey-3'];
+  var origRootVars = {};
+  rootVarNames.forEach(function(v){ origRootVars[v] = csRoot.getPropertyValue(v).trim(); });
+
+  function cssToJs(p){ return p.replace(/-([a-z])/g, function(_,c){ return c.toUpperCase(); }); }
+
+  // ============ 属性组 ============
+  var PROP_GROUPS = [
+    { name: '位置 / 尺寸', props: [
+      {css:'margin-top',label:'上外边距',unit:'px',min:0,max:300,step:1},
+      {css:'margin-bottom',label:'下外边距',unit:'px',min:0,max:300,step:1},
+      {css:'margin-left',label:'左外边距',unit:'px',min:0,max:300,step:1},
+      {css:'margin-right',label:'右外边距',unit:'px',min:0,max:300,step:1},
+      {css:'padding-top',label:'上内边距',unit:'px',min:0,max:200,step:1},
+      {css:'padding-bottom',label:'下内边距',unit:'px',min:0,max:200,step:1},
+      {css:'padding-left',label:'左内边距',unit:'px',min:0,max:200,step:1},
+      {css:'padding-right',label:'右内边距',unit:'px',min:0,max:200,step:1},
+      {css:'width',label:'宽度',unit:'px',min:0,max:1200,step:1},
+      {css:'max-width',label:'最大宽度',unit:'px',min:0,max:1200,step:1},
+      {css:'height',label:'高度',unit:'px',min:0,max:1200,step:1},
+      {css:'gap',label:'间距',unit:'px',min:0,max:200,step:1}
+    ]},
+    { name: '文字', props: [
+      {css:'font-size',label:'字号',unit:'px',min:8,max:300,step:1},
+      {css:'line-height',label:'行高',unit:'',min:0.8,max:3,step:0.05},
+      {css:'letter-spacing',label:'字间距',unit:'em',min:-0.1,max:0.5,step:0.01},
+      {css:'font-weight',label:'字重',unit:'',min:100,max:900,step:100},
+      {css:'color',label:'文字颜色',type:'color'},
+      {css:'text-align',label:'对齐',type:'select',opts:['left','center','right','justify']}
+    ]},
+    { name: '背景 / 边框', props: [
+      {css:'background-color',label:'背景色',type:'color'},
+      {css:'opacity',label:'不透明度',unit:'',min:0,max:1,step:0.05},
+      {css:'border-width',label:'边框宽度',unit:'px',min:0,max:40,step:1},
+      {css:'border-radius',label:'圆角',unit:'px',min:0,max:100,step:1},
+      {css:'border-color',label:'边框颜色',type:'color'}
+    ]},
+    { name: '布局', props: [
+      {css:'flex-direction',label:'方向',type:'select',opts:['row','row-reverse','column','column-reverse']},
+      {css:'align-items',label:'交叉轴对齐',type:'select',opts:['stretch','flex-start','flex-end','center','baseline']},
+      {css:'justify-content',label:'主轴对齐',type:'select',opts:['flex-start','flex-end','center','space-between','space-around','space-evenly']}
+    ]}
+  ];
+
+  // ============ DOM 引用 ============
+  var panel = document.getElementById('edit-panel');
+  var floatBtn = document.getElementById('edit-float-btn');
+  var elSection = document.getElementById('ep-el-section');
+  var elTag = document.getElementById('ep-el-tag');
+  var propsContainer = document.getElementById('ep-props');
+
+  // ============ 编辑模式切换 ============
+  function toggleEditMode() {
+    editMode = !editMode;
+    document.body.classList.toggle('edit-mode', editMode);
+    if (!editMode) clearSelection();
+    updateFloatBtn();
+  }
+  function updateFloatBtn(){ floatBtn.style.opacity = editMode ? '.85' : ''; }
+
+  // ============ 元素选择 ============
+  function clearSelection() {
+    if (selectedEl){ selectedEl.classList.remove('selected'); selectedEl = null; }
+    elSection.style.display = 'none';
+    propsContainer.innerHTML = '';
+  }
+
+  function selectElement(el) {
+    if (selectedEl === el) return;
+    clearSelection();
+    selectedEl = el;
+    el.classList.add('selected');
+    var tag = el.tagName.toLowerCase();
+    var cls = Array.from(el.classList).filter(function(c){ return c !== 'selected'; }).slice(0,3).join('.');
+    elTag.textContent = '<' + tag + '>' + (cls ? ' .' + cls : '');
+    elSection.style.display = 'flex';
+    buildPropertyEditors(el);
+  }
+
+  // ============ 构建属性编辑器 ============
+  function buildPropertyEditors(el) {
+    propsContainer.innerHTML = '';
+    var cs = getComputedStyle(el);
+    var inline = el.style;
+
+    // 文字内容编辑
+    var rawText = el.textContent;
+    if (rawText && rawText.trim()) {
+      var hasKids = el.children.length > 0;
+      var tw = document.createElement('div');
+      tw.style.cssText = 'margin-bottom:12px';
+      var tl = document.createElement('span');
+      tl.style.cssText = 'font-family:var(--mono);font-size:10px;letter-spacing:.1em;display:block;margin-bottom:4px';
+      tl.style.color = isStyleA ? 'rgba(var(--paper-rgb),.45)' : 'var(--text-helper)';
+      tl.textContent = '文字内容' + (hasKids ? ' (含子元素，修改将替换结构)' : '');
+      tw.appendChild(tl);
+      var ta = document.createElement('textarea');
+      ta.rows = Math.min(8, Math.max(2, (rawText.match(/\n/g)||[]).length + 1));
+      ta.value = el.textContent;
+      ta.addEventListener('input', function(){ el.textContent = ta.value; });
+      tw.appendChild(ta);
+      propsContainer.appendChild(tw);
+    }
+
+    PROP_GROUPS.forEach(function(group){
+      var details = document.createElement('details');
+      details.className = 'ep-group';
+      if (group.name === '位置 / 尺寸') details.open = true;
+      var summary = document.createElement('summary');
+      summary.textContent = group.name;
+      details.appendChild(summary);
+      var content = document.createElement('div');
+      content.style.cssText = 'display:flex;flex-direction:column;gap:6px';
+      group.props.forEach(function(pd){
+        var row = createPropRow(el, pd, cs, inline);
+        if (row) content.appendChild(row);
+      });
+      details.appendChild(content);
+      propsContainer.appendChild(details);
+    });
+
+    // 自定义 CSS
+    var cd = document.createElement('details');
+    cd.className = 'ep-group';
+    cd.innerHTML = '<summary>自定义 CSS</summary>';
+    var cc = document.createElement('div');
+    cc.style.cssText = 'display:flex;flex-direction:column;gap:8px';
+    var cta = document.createElement('textarea');
+    cta.rows = 3;
+    cta.placeholder = '例如: box-shadow: 0 2px 8px rgba(0,0,0,.2);\n直接写 CSS 属性: 值; 即可';
+    cc.appendChild(cta);
+    var ab = document.createElement('button');
+    ab.textContent = '应用';
+    ab.style.cssText = 'padding:6px 12px;font-size:11px;border:1px solid;background:transparent;cursor:pointer;align-self:flex-end';
+    ab.style.borderColor = isStyleA ? 'rgba(var(--paper-rgb),.15)' : 'var(--border-subtle)';
+    ab.style.color = isStyleA ? 'rgba(var(--paper-rgb),.55)' : 'var(--text-secondary)';
+    ab.onclick = function(){
+      var text = cta.value.trim();
+      if (!text) return;
+      text.split(';').forEach(function(rule){
+        var ci = rule.indexOf(':');
+        if (ci === -1) return;
+        var prop = rule.substring(0, ci).trim();
+        var val = rule.substring(ci + 1).trim();
+        if (prop && val) applyProperty(el, prop, val);
+      });
+      buildPropertyEditors(el);
+    };
+    cc.appendChild(ab);
+    cd.appendChild(cc);
+    propsContainer.appendChild(cd);
+  }
+
+  function createPropRow(el, pd, cs, inline) {
+    var jsProp = cssToJs(pd.css);
+    var currentVal = inline[jsProp] || cs.getPropertyValue(pd.css);
+
+    if (pd.type === 'color') {
+      var row = document.createElement('div'); row.className = 'ep-row';
+      var lbl = document.createElement('span'); lbl.className = 'ep-label'; lbl.textContent = pd.label;
+      var inp = document.createElement('input'); inp.type = 'color'; inp.value = rgbToHex(currentVal);
+      var vs = document.createElement('span'); vs.className = 'ep-val'; vs.textContent = inp.value;
+      inp.addEventListener('input', function(){ vs.textContent = inp.value; applyProperty(el, pd.css, inp.value); });
+      var rb = document.createElement('button'); rb.className = 'nudge'; rb.textContent = '↺'; rb.title = '重置';
+      rb.onclick = function(){ applyProperty(el, pd.css, ''); inp.value = rgbToHex(cs.getPropertyValue(pd.css)); vs.textContent = inp.value; };
+      row.appendChild(lbl); row.appendChild(inp); row.appendChild(vs); row.appendChild(rb);
+      return row;
+    }
+
+    if (pd.type === 'select') {
+      var row = document.createElement('div'); row.className = 'ep-row';
+      var lbl = document.createElement('span'); lbl.className = 'ep-label'; lbl.textContent = pd.label;
+      var sel = document.createElement('select');
+      pd.opts.forEach(function(o){
+        var opt = document.createElement('option'); opt.value = o; opt.textContent = o;
+        if (currentVal === o) opt.selected = true;
+        sel.appendChild(opt);
+      });
+      sel.addEventListener('change', function(){ applyProperty(el, pd.css, sel.value); });
+      var rb = document.createElement('button'); rb.className = 'nudge'; rb.textContent = '↺'; rb.title = '重置';
+      rb.onclick = function(){ applyProperty(el, pd.css, ''); var rv = cs.getPropertyValue(pd.css); if (rv) sel.value = rv; };
+      row.appendChild(lbl); row.appendChild(sel); row.appendChild(rb);
+      return row;
+    }
+
+    // Numeric
+    var numVal = parseFloat(currentVal);
+    if (isNaN(numVal)) return null;
+
+    var row = document.createElement('div'); row.className = 'ep-row';
+    var lbl = document.createElement('span'); lbl.className = 'ep-label'; lbl.textContent = pd.label;
+    var mb = document.createElement('button'); mb.className = 'nudge'; mb.textContent = '−';
+    var slider = document.createElement('input'); slider.type = 'range';
+    slider.min = pd.min; slider.max = pd.max; slider.step = pd.step;
+    slider.value = Math.min(pd.max, Math.max(pd.min, numVal));
+    var pb = document.createElement('button'); pb.className = 'nudge'; pb.textContent = '+';
+    var vs = document.createElement('span'); vs.className = 'ep-val';
+    var displayVal = pd.step < 1 ? numVal.toFixed(2) : Math.round(numVal);
+    vs.textContent = displayVal + (pd.unit || '');
+    var rb = document.createElement('button'); rb.className = 'nudge'; rb.textContent = '↺'; rb.title = '重置';
+
+    function onChange(){
+      var v = parseFloat(slider.value);
+      var dv = pd.step < 1 ? v.toFixed(2) : Math.round(v);
+      vs.textContent = dv + (pd.unit || '');
+      applyProperty(el, pd.css, v + (pd.unit || ''));
+    }
+    slider.addEventListener('input', onChange);
+    mb.onclick = function(){ slider.value = Math.max(pd.min, parseFloat(slider.value) - pd.step); onChange(); };
+    pb.onclick = function(){ slider.value = Math.min(pd.max, parseFloat(slider.value) + pd.step); onChange(); };
+    rb.onclick = function(){
+      applyProperty(el, pd.css, '');
+      var rv = parseFloat(cs.getPropertyValue(pd.css));
+      if (!isNaN(rv)){ slider.value = Math.min(pd.max, Math.max(pd.min, rv)); onChange(); }
+    };
+    row.appendChild(lbl); row.appendChild(mb); row.appendChild(slider); row.appendChild(pb); row.appendChild(vs); row.appendChild(rb);
+    return row;
+  }
+
+  // ============ 属性读写 ============
+  function applyProperty(el, cssProp, value) {
+    var jsProp = cssToJs(cssProp);
+    if (!editedStyles.has(el)) editedStyles.set(el, {});
+    var orig = editedStyles.get(el);
+    if (!(jsProp in orig)) orig[jsProp] = el.style[jsProp];
+    el.style[jsProp] = (value === '' || value === null) ? orig[jsProp] : value;
+  }
+
+  function rgbToHex(color) {
+    if (!color || color === 'transparent' || color === 'rgba(0, 0, 0, 0)') return '#000000';
+    if (color[0] === '#') {
+      if (color.length === 7) return color;
+      if (color.length === 4) return '#' + color[1]+color[1]+color[2]+color[2]+color[3]+color[3];
+      return color;
+    }
+    var m = color.match(/[\d.]+/g);
+    if (!m || m.length < 3) return '#000000';
+    return '#' + [parseInt(m[0]), parseInt(m[1]), parseInt(m[2])].map(function(v){ return v.toString(16).padStart(2,'0'); }).join('');
+  }
+
+  // ============ 全局: 主题切换 ============
+  (function(){
+    var themes = isStyleA ? {
+      ink:    {vars:{'--ink':'#0a0a0b','--ink-rgb':'10,10,11','--paper':'#f1efea','--paper-rgb':'241,239,234','--paper-tint':'#e8e5de','--ink-tint':'#18181a'}, label:'🖋 墨水经典'},
+      indigo: {vars:{'--ink':'#0a1f3d','--ink-rgb':'10,31,61','--paper':'#f1f3f5','--paper-rgb':'241,243,245','--paper-tint':'#e4e8ec','--ink-tint':'#152a4a'}, label:'🌊 靛蓝瓷'},
+      forest: {vars:{'--ink':'#1a2e1f','--ink-rgb':'26,46,31','--paper':'#f5f1e8','--paper-rgb':'245,241,232','--paper-tint':'#ece7da','--ink-tint':'#253d2c'}, label:'🌿 森林墨'},
+      kraft:  {vars:{'--ink':'#2a1e13','--ink-rgb':'42,30,19','--paper':'#eedfc7','--paper-rgb':'238,223,199','--paper-tint':'#e0d0b6','--ink-tint':'#3a2a1d'}, label:'🍂 牛皮纸'},
+      dune:   {vars:{'--ink':'#1f1a14','--ink-rgb':'31,26,20','--paper':'#f0e6d2','--paper-rgb':'240,230,210','--paper-tint':'#e3d7bf','--ink-tint':'#2d2620'}, label:'🌙 沙丘'}
+    } : {
+      ikb:    {vars:{'--accent':'#002FA7','--accent-rgb':'0,47,167','--accent-bright':'#5B7BFF','--accent-on':'#ffffff'}, label:'🔵 IKB 克莱因蓝'},
+      lemon:  {vars:{'--accent':'#E8C300','--accent-rgb':'232,195,0','--accent-bright':'#FFD940','--accent-on':'#0a0a0a'}, label:'🟡 柠檬黄'},
+      lime:   {vars:{'--accent':'#A3E635','--accent-rgb':'163,230,53','--accent-bright':'#BEF264','--accent-on':'#0a0a0a'}, label:'🟢 柠檬绿'},
+      orange: {vars:{'--accent':'#FF6B35','--accent-rgb':'255,107,53','--accent-bright':'#FF8C60','--accent-on':'#ffffff'}, label:'🟠 安全橙'}
+    };
+    var sel = document.getElementById('ep-theme');
+    Object.keys(themes).forEach(function(k){
+      var o = document.createElement('option');
+      o.value = k; o.textContent = themes[k].label;
+      sel.appendChild(o);
+    });
+    sel.addEventListener('change', function(){
+      var t = themes[sel.value];
+      if (!t) return;
+      Object.keys(t.vars).forEach(function(p){ root.style.setProperty(p, t.vars[p]); });
+    });
+  })();
+
+  // 整体缩放
+  document.getElementById('ep-zoom').addEventListener('input', function(){
+    var v = parseFloat(this.value);
+    document.getElementById('ep-zoom-val').textContent = v.toFixed(2) + 'x';
+    root.style.zoom = v;
+  });
+
+  // 间距档位 (仅 Style B Swiss 有效)
+  if (!isStyleA) {
+    var presets = {
+      compact: {'--sp-3':'4px','--sp-4':'8px','--sp-5':'12px','--sp-6':'16px','--sp-7':'24px','--sp-8':'32px','--sp-9':'40px','--sp-10':'48px','--sp-11':'64px','--sp-12':'80px','--sp-13':'128px'},
+      normal:  {'--sp-3':'8px','--sp-4':'12px','--sp-5':'16px','--sp-6':'24px','--sp-7':'32px','--sp-8':'40px','--sp-9':'48px','--sp-10':'64px','--sp-11':'80px','--sp-12':'96px','--sp-13':'160px'},
+      loose:   {'--sp-3':'12px','--sp-4':'16px','--sp-5':'24px','--sp-6':'32px','--sp-7':'48px','--sp-8':'56px','--sp-9':'64px','--sp-10':'80px','--sp-11':'104px','--sp-12':'128px','--sp-13':'200px'}
+    };
+    document.getElementById('ep-spacing').addEventListener('change', function(){
+      var p = presets[this.value];
+      if (!p) return;
+      Object.keys(p).forEach(function(k){ root.style.setProperty(k, p[k]); });
+    });
+  } else {
+    document.getElementById('ep-spacing-row').style.display = 'none';
+  }
+
+  // ============ 导出 ============
+  document.getElementById('ep-download').addEventListener('click', function(){
+    var wasEdit = editMode;
+    panel.style.display = 'none';
+    floatBtn.style.display = 'none';
+    document.body.classList.remove('edit-mode');
+    document.querySelectorAll('.selected').forEach(function(el){ el.classList.remove('selected'); });
+
+    var html = '<!DOCTYPE html>\n' + document.documentElement.outerHTML;
+
+    panel.style.display = '';
+    floatBtn.style.display = '';
+    if (wasEdit) document.body.classList.add('edit-mode');
+    if (selectedEl) selectedEl.classList.add('selected');
+
+    var blob = new Blob([html], {type: 'text/html;charset=utf-8'});
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url; a.download = 'index.html';
+    document.body.appendChild(a); a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+
+  // ============ 重置 ============
+  document.getElementById('ep-reset').addEventListener('click', function(){
+    if (confirm('确定要重置所有修改吗？页面将刷新回到初始状态。')) location.reload();
+  });
+
+  // ============ 退出 ============
+  document.getElementById('ep-exit').addEventListener('click', toggleEditMode);
+  document.querySelector('#edit-panel .ep-close').addEventListener('click', toggleEditMode);
+  floatBtn.addEventListener('click', toggleEditMode);
+
+  // 清除单元素修改
+  document.getElementById('ep-clear-styles').addEventListener('click', function(){
+    if (!selectedEl) return;
+    if (editedStyles.has(selectedEl)) {
+      var orig = editedStyles.get(selectedEl);
+      Object.keys(orig).forEach(function(p){ selectedEl.style[p] = orig[p]; });
+      editedStyles.delete(selectedEl);
+    }
+    buildPropertyEditors(selectedEl);
+  });
+
+  // ============ 点击选中 ============
+  document.addEventListener('click', function(e){
+    if (!editMode) return;
+    if (panel.contains(e.target)) return;
+    if (floatBtn.contains(e.target)) return;
+    if (e.target.closest('#nav')) return;
+    var ov = document.getElementById('overview');
+    if (ov && ov.style.display === 'block') return;
+    if (e.target.tagName === 'CANVAS') return;
+    var slide = e.target.closest('.slide');
+    if (!slide) return;
+    if (e.target === slide) return;
+    e.preventDefault();
+    e.stopPropagation();
+    selectElement(e.target);
+  }, true);
+
+  // ============ E 键切换 ============
+  addEventListener('keydown', function(e){
+    if (e.key && e.key.toLowerCase() === 'e' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      var tag = (e.target.tagName || '');
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
+      var ov = document.getElementById('overview');
+      if (ov && ov.style.display === 'block') return;
+      e.preventDefault();
+      toggleEditMode();
+    }
+  });
+
+  updateFloatBtn();
+})();

--- a/assets/edit-panel/panel.html
+++ b/assets/edit-panel/panel.html
@@ -1,0 +1,21 @@
+<!-- WYSIWYG 编辑面板 -->
+<div id="edit-panel">
+  <div class="ep-header"><span>编辑模式</span><button class="ep-close" title="退出编辑 (E)">×</button></div>
+  <div class="ep-section">
+    <div class="ep-section-title">全局设置</div>
+    <div class="ep-row"><span class="ep-label">主题色</span><select id="ep-theme"><option value="">当前主题</option></select></div>
+    <div class="ep-row"><span class="ep-label">整体缩放</span><input type="range" id="ep-zoom" min="0.7" max="1.5" step="0.05" value="1"><span class="ep-val" id="ep-zoom-val">1.0x</span></div>
+    <div class="ep-row" id="ep-spacing-row"><span class="ep-label">间距档位</span><select id="ep-spacing"><option value="compact">紧凑</option><option value="normal" selected>标准</option><option value="loose">宽松</option></select></div>
+  </div>
+  <div class="ep-section" id="ep-el-section" style="display:none">
+    <div class="ep-section-title">元素属性 <span class="ep-el-info" id="ep-el-tag"></span></div>
+    <div id="ep-props"></div>
+    <div style="margin-top:8px"><button class="ep-clear-btn" id="ep-clear-styles">清除此元素所有修改</button></div>
+  </div>
+  <div class="ep-actions">
+    <button class="ep-btn-primary" id="ep-download">⬇ 下载 HTML</button>
+    <button id="ep-reset">↺ 重置所有修改</button>
+    <button id="ep-exit">✕ 退出编辑模式</button>
+  </div>
+</div>
+<button id="edit-float-btn" title="编辑模式 (E)"><i data-lucide="pencil"></i></button>

--- a/assets/edit-panel/style-a.css
+++ b/assets/edit-panel/style-a.css
@@ -1,0 +1,70 @@
+/* ============ WYSIWYG 编辑面板 - Style A Magazine ============ */
+/* 浮动触发按钮 */
+#edit-float-btn{position:fixed;bottom:2vh;right:7vw;z-index:31;width:34px;height:34px;border:1px solid rgba(var(--paper-rgb),.2);background:var(--ink);color:var(--paper);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:14px;opacity:.5;transition:opacity .2s}
+#edit-float-btn:hover{opacity:.85}
+body.light-bg #edit-float-btn{border-color:rgba(var(--ink-rgb),.12);background:var(--paper);color:var(--ink)}
+
+/* 编辑模式下元素高亮 */
+.edit-mode .slide *{transition:outline .08s}
+.edit-mode .slide :hover:not(canvas):not([data-no-edit]){outline:1.5px dashed rgba(var(--paper-rgb),.35);outline-offset:1px}
+body.light-bg.edit-mode .slide :hover:not(canvas):not([data-no-edit]){outline-color:rgba(var(--ink-rgb),.28)}
+.edit-mode .selected{outline:2px solid var(--ink)!important;outline-offset:2px}
+body.light-bg.edit-mode .selected{outline-color:var(--ink)!important}
+.edit-mode #nav,.edit-mode #hint,.edit-mode #edit-float-btn,.edit-mode canvas,.edit-mode .bg{pointer-events:none!important}
+
+/* 编辑面板 — 默认暗底(匹配 dark slide) */
+#edit-panel{position:fixed;top:0;right:-360px;width:340px;height:100vh;z-index:50;background:rgba(var(--ink-rgb),.97);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-left:1px solid rgba(var(--paper-rgb),.1);overflow-y:auto;padding:20px;font-family:var(--sans-zh);font-size:13px;color:var(--paper);display:flex;flex-direction:column;gap:16px;transition:right .25s ease;scrollbar-width:thin}
+.edit-mode #edit-panel{right:0}
+body.light-bg #edit-panel{background:rgba(var(--paper-rgb),.97);border-left-color:rgba(var(--ink-rgb),.08);color:var(--ink)}
+
+#edit-panel .ep-header{display:flex;justify-content:space-between;align-items:center;font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;padding-bottom:12px;border-bottom:1px solid rgba(var(--paper-rgb),.12)}
+body.light-bg #edit-panel .ep-header{border-bottom-color:rgba(var(--ink-rgb),.1)}
+#edit-panel .ep-close{background:none;border:none;font-size:20px;cursor:pointer;color:rgba(var(--paper-rgb),.55);line-height:1;padding:0}
+body.light-bg #edit-panel .ep-close{color:rgba(var(--ink-rgb),.45)}
+#edit-panel .ep-close:hover{color:var(--paper)}
+body.light-bg #edit-panel .ep-close:hover{color:var(--ink)}
+#edit-panel .ep-section{display:flex;flex-direction:column;gap:10px}
+#edit-panel .ep-section-title{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:rgba(var(--paper-rgb),.45);margin-bottom:2px;display:flex;gap:8px;align-items:baseline}
+body.light-bg #edit-panel .ep-section-title{color:rgba(var(--ink-rgb),.45)}
+#edit-panel .ep-section-title .ep-el-info{font-family:var(--serif-zh);font-size:12px;text-transform:none;letter-spacing:0;color:var(--paper);font-weight:500}
+body.light-bg #edit-panel .ep-section-title .ep-el-info{color:var(--ink)}
+
+#edit-panel .ep-row{display:flex;align-items:center;gap:6px}
+#edit-panel .ep-row .ep-label{min-width:62px;font-size:11px;color:rgba(var(--paper-rgb),.55);flex-shrink:0}
+body.light-bg #edit-panel .ep-row .ep-label{color:rgba(var(--ink-rgb),.55)}
+#edit-panel .ep-row select,#edit-panel .ep-row input[type=number]{padding:4px 6px;font-size:11px;border:1px solid rgba(var(--paper-rgb),.15);background:transparent;color:var(--paper);font-family:inherit;min-width:0}
+body.light-bg #edit-panel .ep-row select,body.light-bg #edit-panel .ep-row input[type=number]{border-color:rgba(var(--ink-rgb),.12);color:var(--ink)}
+#edit-panel .ep-row input[type=color]{width:26px;height:24px;border:1px solid rgba(var(--paper-rgb),.15);padding:2px;background:transparent;cursor:pointer}
+body.light-bg #edit-panel .ep-row input[type=color]{border-color:rgba(var(--ink-rgb),.12)}
+#edit-panel .ep-row input[type=range]{flex:1;accent-color:var(--paper);height:4px;min-width:40px}
+body.light-bg #edit-panel .ep-row input[type=range]{accent-color:var(--ink)}
+#edit-panel .ep-row .ep-val{min-width:44px;text-align:right;font-family:var(--mono);font-size:10px;color:rgba(var(--paper-rgb),.55)}
+body.light-bg #edit-panel .ep-row .ep-val{color:rgba(var(--ink-rgb),.55)}
+#edit-panel .ep-row button.nudge{width:20px;height:20px;border:1px solid rgba(var(--paper-rgb),.15);background:transparent;color:rgba(var(--paper-rgb),.55);cursor:pointer;font-size:13px;line-height:1;display:flex;align-items:center;justify-content:center;flex-shrink:0;padding:0}
+body.light-bg #edit-panel .ep-row button.nudge{border-color:rgba(var(--ink-rgb),.12);color:rgba(var(--ink-rgb),.45)}
+#edit-panel .ep-row button.nudge:hover{background:rgba(var(--paper-rgb),.1);color:var(--paper)}
+body.light-bg #edit-panel .ep-row button.nudge:hover{background:rgba(var(--ink-rgb),.08);color:var(--ink)}
+
+#edit-panel .ep-group{border:0}
+#edit-panel .ep-group summary{font-family:var(--mono);font-size:10px;letter-spacing:.1em;color:rgba(var(--paper-rgb),.45);cursor:pointer;padding:6px 0;border-bottom:1px solid rgba(var(--paper-rgb),.12);margin-bottom:8px}
+body.light-bg #edit-panel .ep-group summary{color:rgba(var(--ink-rgb),.45);border-bottom-color:rgba(var(--ink-rgb),.1)}
+#edit-panel .ep-group[open] summary{color:var(--paper)}
+body.light-bg #edit-panel .ep-group[open] summary{color:var(--ink)}
+
+#edit-panel textarea{width:100%;padding:8px;font-size:11px;font-family:inherit;resize:vertical;border:1px solid rgba(var(--paper-rgb),.15);background:transparent;color:var(--paper)}
+body.light-bg #edit-panel textarea{border-color:rgba(var(--ink-rgb),.12);color:var(--ink)}
+#edit-panel textarea:focus{outline:1px solid var(--paper)}
+body.light-bg #edit-panel textarea:focus{outline-color:var(--ink)}
+
+#edit-panel .ep-actions{display:flex;flex-direction:column;gap:8px;padding-top:16px;border-top:1px solid rgba(var(--paper-rgb),.12);margin-top:auto;flex-shrink:0}
+body.light-bg #edit-panel .ep-actions{border-top-color:rgba(var(--ink-rgb),.1)}
+#edit-panel .ep-actions button{padding:10px;font-size:13px;font-family:inherit;cursor:pointer;border:1px solid rgba(var(--paper-rgb),.2);background:transparent;color:var(--paper)}
+body.light-bg #edit-panel .ep-actions button{border-color:rgba(var(--ink-rgb),.15);color:var(--ink)}
+#edit-panel .ep-actions button:hover{opacity:.82}
+#edit-panel .ep-actions .ep-btn-primary{background:var(--paper);color:var(--ink);border-color:var(--paper)}
+body.light-bg #edit-panel .ep-actions .ep-btn-primary{background:var(--ink);color:var(--paper);border-color:var(--ink)}
+#edit-panel .ep-actions .ep-btn-danger{color:#c0392b}
+#edit-panel .ep-clear-btn{font-size:11px;padding:4px 10px;border:1px solid rgba(var(--paper-rgb),.15);background:transparent;color:rgba(var(--paper-rgb),.55);cursor:pointer}
+body.light-bg #edit-panel .ep-clear-btn{color:rgba(var(--ink-rgb),.45)}
+
+@media(max-width:600px){#edit-panel{width:280px}}

--- a/assets/edit-panel/style-b.css
+++ b/assets/edit-panel/style-b.css
@@ -1,0 +1,50 @@
+/* ============ WYSIWYG 编辑面板 - Style B Swiss ============ */
+/* 浮动触发按钮 */
+#edit-float-btn{position:fixed;bottom:2vh;right:7vw;z-index:31;width:34px;height:34px;border:1px solid rgba(0,0,0,.12);background:var(--paper);color:var(--ink);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:14px;opacity:.4;transition:opacity .2s}
+#edit-float-btn:hover{opacity:.85}
+body.dark-bg #edit-float-btn{border-color:rgba(255,255,255,.15);background:var(--ink);color:var(--paper)}
+
+/* 编辑模式下元素高亮 */
+.edit-mode .slide *{transition:outline .08s}
+.edit-mode .slide :hover:not(canvas):not(.ascii-canvas):not([data-no-edit]){outline:1.5px dashed rgba(0,0,0,.28);outline-offset:1px}
+body.dark-bg.edit-mode .slide :hover:not(canvas):not(.ascii-canvas):not([data-no-edit]){outline-color:rgba(255,255,255,.3)}
+.edit-mode .selected{outline:2px solid var(--accent)!important;outline-offset:2px}
+.edit-mode #nav,.edit-mode #hint,.edit-mode #edit-float-btn,.edit-mode canvas,.edit-mode .bg{pointer-events:none!important}
+
+/* 编辑面板 */
+#edit-panel{position:fixed;top:0;right:-360px;width:340px;height:100vh;z-index:50;background:rgba(250,250,248,.97);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-left:1px solid rgba(0,0,0,.08);overflow-y:auto;padding:20px;font-family:var(--sans),var(--sans-zh);font-size:13px;color:var(--text-primary);display:flex;flex-direction:column;gap:16px;transition:right .25s var(--ease-prod);scrollbar-width:thin}
+.edit-mode #edit-panel{right:0}
+body.dark-bg #edit-panel{background:rgba(10,10,10,.97);border-left-color:rgba(255,255,255,.08);color:var(--paper)}
+
+#edit-panel .ep-header{display:flex;justify-content:space-between;align-items:center;font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;padding-bottom:12px;border-bottom:1px solid var(--border-subtle)}
+#edit-panel .ep-close{background:none;border:none;font-size:20px;cursor:pointer;color:var(--text-secondary);line-height:1;padding:0}
+#edit-panel .ep-close:hover{color:var(--text-primary)}
+#edit-panel .ep-section{display:flex;flex-direction:column;gap:10px}
+#edit-panel .ep-section-title{font-family:var(--mono);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--text-helper);margin-bottom:2px;display:flex;gap:8px;align-items:baseline}
+#edit-panel .ep-section-title .ep-el-info{font-family:var(--sans);font-size:11px;text-transform:none;letter-spacing:0;color:var(--accent);font-weight:500}
+
+#edit-panel .ep-row{display:flex;align-items:center;gap:6px}
+#edit-panel .ep-row .ep-label{min-width:62px;font-size:11px;color:var(--text-secondary);flex-shrink:0}
+#edit-panel .ep-row select,#edit-panel .ep-row input[type=number]{padding:4px 6px;font-size:11px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-primary);font-family:inherit;min-width:0}
+#edit-panel .ep-row input[type=color]{width:26px;height:24px;border:1px solid var(--border-subtle);padding:2px;background:transparent;cursor:pointer}
+#edit-panel .ep-row input[type=range]{flex:1;accent-color:var(--accent);height:4px;min-width:40px}
+#edit-panel .ep-row .ep-val{min-width:44px;text-align:right;font-family:var(--mono);font-size:10px;color:var(--text-secondary)}
+#edit-panel .ep-row button.nudge{width:20px;height:20px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-secondary);cursor:pointer;font-size:13px;line-height:1;display:flex;align-items:center;justify-content:center;flex-shrink:0;padding:0}
+#edit-panel .ep-row button.nudge:hover{background:var(--grey-1);color:var(--text-primary)}
+body.dark-bg #edit-panel .ep-row button.nudge:hover{background:rgba(255,255,255,.08)}
+
+#edit-panel .ep-group{border:0}
+#edit-panel .ep-group summary{font-family:var(--mono);font-size:10px;letter-spacing:.1em;color:var(--text-helper);cursor:pointer;padding:6px 0;border-bottom:1px solid var(--border-subtle);margin-bottom:8px}
+#edit-panel .ep-group[open] summary{color:var(--accent)}
+
+#edit-panel textarea{width:100%;padding:8px;font-size:11px;font-family:inherit;resize:vertical;border:1px solid var(--border-subtle);background:transparent;color:var(--text-primary)}
+#edit-panel textarea:focus{outline:1px solid var(--accent)}
+
+#edit-panel .ep-actions{display:flex;flex-direction:column;gap:8px;padding-top:16px;border-top:1px solid var(--border-subtle);margin-top:auto;flex-shrink:0}
+#edit-panel .ep-actions button{padding:10px;font-size:13px;font-family:inherit;cursor:pointer;border:1px solid var(--border-subtle);background:transparent;color:var(--text-primary)}
+#edit-panel .ep-actions button:hover{opacity:.82}
+#edit-panel .ep-actions .ep-btn-primary{background:var(--accent);color:var(--accent-on);border-color:var(--accent)}
+#edit-panel .ep-actions .ep-btn-danger{color:#c00}
+#edit-panel .ep-clear-btn{font-size:11px;padding:4px 10px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-secondary);cursor:pointer}
+
+@media(max-width:600px){#edit-panel{width:280px}}

--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -1180,6 +1180,8 @@
     .grid-2-7-5,.grid-2-6-6,.grid-2-8-4,.grid-2-4-8{grid-template-columns:1fr}
     .grid-12{grid-template-columns:repeat(6,1fr)}
   }
+
+  /* @edit-panel-css */
 </style>
 </head>
 <body class="canvas-mode">
@@ -1215,6 +1217,8 @@
 
 <canvas id="bg-grid" class="bg"></canvas>
 <div id="hint">← → 翻页 · B 静态 · ESC 索引</div>
+
+<!-- @edit-panel -->
 
 <div id="deck">
 
@@ -1597,6 +1601,9 @@ const initialSlideParam = new URLSearchParams(location.search).get('slide');
 const initialSlide = initialSlideParam ? Number(initialSlideParam) - 1 : 0;
 go(Number.isFinite(initialSlide) ? initialSlide : 0);
 </script>
+
+<!-- @edit-panel-js -->
+
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script>lucide.createIcons();</script>
 

--- a/assets/template.html
+++ b/assets/template.html
@@ -443,6 +443,8 @@
     .pipeline{grid-template-columns:repeat(2,1fr)}
     .grid-2-7-5,.grid-2-6-6,.grid-2-8-4{grid-template-columns:1fr}
   }
+
+  /* @edit-panel-css */
 </style>
 </head>
 <body>
@@ -475,6 +477,8 @@
 <canvas id="bg-dark" class="bg"></canvas>
 <canvas id="bg-light" class="bg"></canvas>
 <div id="hint">← → 翻页 · B 静态 · ESC 索引</div>
+
+<!-- @edit-panel -->
 
 <div id="deck">
 
@@ -732,6 +736,9 @@ addEventListener('touchend',e=>{
 
 go(0);
 </script>
+
+<!-- @edit-panel-js -->
+
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script>lucide.createIcons();</script>
 

--- a/references/checklist.md
+++ b/references/checklist.md
@@ -510,6 +510,22 @@ JS 会动态算总页数并扩展底部翻页圆点，但 `.chrome` 里的 `XX /
 
 `100vh` 会让内容刚好卡满屏幕，但浏览器工具栏、标签栏会吃掉一部分高度，导致内容溢出。用 `min-height:80vh + align-content:center` 更稳。
 
+### 19. WYSIWYG 编辑面板功能验证
+
+生成 PPT 后，在浏览器中验证内置编辑面板是否正常工作：
+
+```
+编辑面板自检
+  □ 按 E 键 → 编辑面板从右侧滑入，右下角 ✏️ 按钮高亮
+  □ 鼠标划过 slide 内元素 → 出现虚线高亮框
+  □ 点击某个元素 → 蓝色实线选中框，面板显示元素属性
+  □ 拖动 margin/font-size 滑块 → 元素实时变化
+  □ 切换主题色下拉 → 全局颜色即时生效
+  □ 点「下载 HTML」→ 成功下载 .html 文件
+  □ 点「重置所有修改」→ 页面刷新恢复初始状态
+  □ 再按 E 或点「退出编辑模式」→ 面板消失
+```
+
 ---
 
 ## 🧪 最终自检清单
@@ -522,6 +538,7 @@ JS 会动态算总页数并扩展底部翻页圆点，但 `.chrome` 里的 `XX /
   □ 已决定每页用哪个 Layout(1-10)
   □ 已画出"主题节奏表":每页明确 hero dark / hero light / light / dark
   □ 节奏表满足硬规则:无连续 3 页同主题 / 有 ≥1 hero dark + ≥1 hero light(8 页以上) / 至少有 1 个 dark 正文页
+  □ 编辑面板(E 键)可正常打开、选中元素、调整属性、下载导出
   □ `<title>` 已改为实际 deck 标题(grep "[必填]" 应无结果)
   □ 瑞士风:封面是 `slide accent` 满屏 IKB + `<canvas class="ascii-bg">`(不是 `slide light` 白底)
   □ 瑞士风:封底是 `slide split` + 左 `b-accent` + ASCII canvas / 右 paper 3 条 takeaway,第 03 条用 var(--accent)

--- a/scripts/inject-edit-panel.mjs
+++ b/scripts/inject-edit-panel.mjs
@@ -1,0 +1,35 @@
+// 将 WYSIWYG 编辑面板注入生成的 HTML 文件
+// 用法: node scripts/inject-edit-panel.mjs <path/to/index.html>
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skillRoot = resolve(__dirname, '..');
+
+const htmlPath = process.argv[2];
+if (!htmlPath) {
+  console.error('用法: node scripts/inject-edit-panel.mjs <path/to/index.html>');
+  process.exit(1);
+}
+
+let html = readFileSync(htmlPath, 'utf8');
+
+// 检测模板类型: Style B (Swiss) 有 --accent 或 data-layout, Style A (Magazine) 有 --ink-tint
+const isStyleB = html.includes('--accent') || html.includes('data-layout');
+
+// 读取对应资源
+const cssFile = isStyleB ? 'assets/edit-panel/style-b.css' : 'assets/edit-panel/style-a.css';
+const css = readFileSync(resolve(skillRoot, cssFile), 'utf8');
+const panelHtml = readFileSync(resolve(skillRoot, 'assets/edit-panel/panel.html'), 'utf8');
+const js = readFileSync(resolve(skillRoot, 'assets/edit-panel/editor.js'), 'utf8');
+
+// 替换标记
+html = html.replace('/* @edit-panel-css */', css);
+html = html.replace('<!-- @edit-panel -->', panelHtml);
+html = html.replace('<!-- @edit-panel-js -->', '<script>\n' + js + '\n</script>');
+html = html.replace('← → 翻页 · B 静态 · ESC 索引', '← → 翻页 · E 编辑 · B 静态 · ESC 索引');
+
+writeFileSync(htmlPath, html, 'utf8');
+console.log('✅ 编辑面板已注入: ' + htmlPath + ' (Style ' + (isStyleB ? 'B' : 'A') + ')');


### PR DESCRIPTION
新增浏览器端可视化编辑器，用户生成 PPT 后可按 E 键打开面板，
点击页面元素实时调整 CSS 属性、文字内容和主题色，修改满意后下载 HTML。

**设计思路**：
编辑面板代码存放在 assets/edit-panel/ 独立文件中，通过 scripts/inject-edit-panel.mjs 在生成后注入到 HTML。模板里只放 3 个极小的注入标记（@edit-panel），agent 读模板时 完全不需要消耗 token 去加载编辑面板代码。

**使用方式**：
  1. 按正常流程生成 PPT（Step 2-4）
  2. 运行：node scripts/inject-edit-panel.mjs 项目/XXX/ppt/index.html
  3. 浏览器打开 index.html，按 E 键进入编辑模式
  4. 点击元素、拖动滑块、切换主题色、下载修改后的 HTML

**文件清单**：
- assets/edit-panel/editor.js   — 编辑器核心逻辑（自动检测风格 A/B）
- assets/edit-panel/panel.html  — 面板 HTML 骨架
- assets/edit-panel/style-a.css — 风格 A 面板样式
- assets/edit-panel/style-b.css — 风格 B 面板样式
- scripts/inject-edit-panel.mjs — 注入脚本（35 行）
- SKILL.md                     — 新增 Step 5 注入编辑面板 + 本地预览
- assets/template*.html        — 各加 3 个注入标记
- references/checklist.md      — 编辑面板功能自检项
- .gitignore                   — 追加 node_modules/

**为什么用外置注入而非直接写在模板里**：
agent 每次生成 PPT 都要读模板，用户修改 PPT 的频率远低于 agent 读模板的频率。 把编辑面板的 500+ 行代码放在模板外面，每次为 agent 省下这些 token 开销。

## Summary

- 

## What Changed

- 

## Visual QA

Please attach screenshots for visual changes.

- [ ] Checked at least one dense text slide
- [ ] Checked at least one image slide
- [ ] Checked navigation / ESC overview / low-power mode when relevant

## Validation

- [ ] `node scripts/validate-swiss-deck.mjs path/to/index.html`
- [ ] Manual browser review

## Notes

Any tradeoffs, limitations, or follow-up work:
