### PR TITLE
feat: click-to-navigate on decks (left 1/3 prev, right 2/3 next)

### DIFF
--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -1149,7 +1149,7 @@
     window.__lowPowerMode = stored === '1' || (stored === null && reduced);
     function updateHint(){
       const hint = document.getElementById('hint');
-      if(hint) hint.textContent = `← → 翻页 · B ${window.__lowPowerMode ? '动态' : '静态'} · ESC 索引`;
+      if(hint) hint.textContent = `点击翻页 · ← → · B ${window.__lowPowerMode ? '动态' : '静态'} · ESC 索引`;
     }
     window.__setLowPowerMode = function(on, opts={}){
       window.__lowPowerMode = !!on;
@@ -1168,7 +1168,7 @@
 </script>
 
 <canvas id="bg-grid" class="bg"></canvas>
-<div id="hint">← → 翻页 · B 静态 · ESC 索引</div>
+<div id="hint">点击翻页 · ← → · B 静态 · ESC 索引</div>
 
 <div id="deck">
 
@@ -1540,6 +1540,14 @@ addEventListener('touchend',e=>{
     go(idx+(dx<0?1:-1));
   }
 },{passive:true});
+
+/* 点击翻页：左 1/3 上一页,右 2/3 下一页。前进与键盘/滚轮/触屏一致,先让分步动效消费一步 */
+deck.addEventListener('click',e=>{
+  if(e.target.closest('button,a,input,select,textarea'))return;
+  if(e.clientX/window.innerWidth<1/3){go(idx-1);return;}
+  if(window.__pipeAdvance && window.__pipeAdvance())return;
+  go(idx+1);
+});
 
 const initialSlideParam = new URLSearchParams(location.search).get('slide');
 const initialSlide = initialSlideParam ? Number(initialSlideParam) - 1 : 0;

--- a/assets/template.html
+++ b/assets/template.html
@@ -452,7 +452,7 @@
     window.__lowPowerMode = stored === '1' || (stored === null && reduced);
     function updateHint(){
       const hint = document.getElementById('hint');
-      if(hint) hint.textContent = `← → 翻页 · B ${window.__lowPowerMode ? '动态' : '静态'} · ESC 索引`;
+      if(hint) hint.textContent = `点击翻页 · ← → · B ${window.__lowPowerMode ? '动态' : '静态'} · ESC 索引`;
     }
     window.__setLowPowerMode = function(on, opts={}){
       window.__lowPowerMode = !!on;
@@ -472,7 +472,7 @@
 
 <canvas id="bg-dark" class="bg"></canvas>
 <canvas id="bg-light" class="bg"></canvas>
-<div id="hint">← → 翻页 · B 静态 · ESC 索引</div>
+<div id="hint">点击翻页 · ← → · B 静态 · ESC 索引</div>
 
 <div id="deck">
 
@@ -727,6 +727,14 @@ addEventListener('touchend',e=>{
     go(idx+(dx<0?1:-1));
   }
 },{passive:true});
+
+/* 点击翻页：左 1/3 上一页,右 2/3 下一页。前进与键盘/滚轮/触屏一致,先让分步动效消费一步 */
+deck.addEventListener('click',e=>{
+  if(e.target.closest('button,a,input,select,textarea'))return;
+  if(e.clientX/window.innerWidth<1/3){go(idx-1);return;}
+  if(window.__pipeAdvance && window.__pipeAdvance())return;
+  go(idx+1);
+});
 
 /* ?slide=N 直达（1-based），与 Swiss 模板行为一致 */
 const initialSlideParam = new URLSearchParams(location.search).get('slide');


### PR DESCRIPTION
## Problem

Decks are only navigable by keyboard, wheel, or touch swipe. When presenting from a trackpad, or with a clicker/remote that only emits a plain click, you have to reach back for the arrow keys.

## Change

Adds click navigation to both `assets/template.html` and `assets/template-swiss.html`: left 1/3 of the viewport goes back, right 2/3 goes forward.

```js
deck.addEventListener('click',e=>{
  if(e.target.closest('button,a,input,select,textarea'))return;
  if(e.clientX/window.innerWidth<1/3){go(idx-1);return;}
  if(window.__pipeAdvance && window.__pipeAdvance())return;
  go(idx+1);
});
```

Three things worth calling out, since they're about staying consistent with what's already there:

- **Staged reveals are respected.** `keydown`, `wheel`, and `touchend` all call `window.__pipeAdvance()` before advancing. Forward-click does the same, so a slide with staged content steps through its reveals instead of skipping to the next slide. Backward-click doesn't, matching the existing handlers.
- **No extra guards were needed.** `go()` already clamps to `[0, total-1]` and holds a 700ms `lock`, so out-of-range clicks and double-fire are covered by existing code.
- **`#nav` and `#overview` need no exclusion.** Both live outside `#deck` (`#nav` is `position:fixed` at z-index 30; the overview overlay is appended to `document.body` at z-index 100), so the listener never sees those clicks. I verified this rather than adding defensive selectors — the dots and the ESC thumbnails keep working untouched.

Hint text updated to advertise the affordance: `← → 翻页 · …` → `点击翻页 · ← → · …`.

## Files changed

| File | Diff |
|---|---|
| `assets/template.html` | +10 / −2 |
| `assets/template-swiss.html` | +10 / −2 |

## QA

`scripts/validate-swiss-deck.mjs` output is byte-identical before and after this change (the pre-existing `data-layout` complaints come from the bare template skeleton, which has no `.slide` elements of its own).

Behavior was checked with Playwright/Chromium on decks generated from both templates (4 and 6 slides), **22/22 assertions passing, no runtime errors**:

| Check | Magazine | Swiss |
|---|---|---|
| Right 2/3 click advances | ✅ | ✅ |
| Left 1/3 click goes back | ✅ | ✅ |
| First slide, left click — no underflow | ✅ | ✅ |
| Last slide, right click — no overflow | ✅ | ✅ |
| Click on in-slide `<button>` doesn't navigate | ✅ | ✅ |
| Click on in-slide `<a>` doesn't navigate | ✅ | ✅ |
| ESC overview open — `#deck` receives no click | ✅ | ✅ |
| Staged reveal pending — forward click doesn't skip slide | ✅ | n/a¹ |
| Staged reveal done — forward click advances | ✅ | n/a¹ |
| Back click never calls `__pipeAdvance` | ✅ | n/a¹ |
| Hint text updated | ✅ | ✅ |

¹ The Swiss template has no `__pipeAdvance`; the `window.__pipeAdvance &&` guard short-circuits there, verified no error.

No new default body layouts, no changes to the registered layout system or Swiss visual rules — this is runtime navigation behavior only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)