### PR TITLE
Add MiniMax image generation adapter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -174,6 +174,21 @@ git -C "<SKILL_ROOT>" pull --ff-only
 - 配图比例必须匹配最终落位:主视觉 16:9,左文右图 16:10 / 4:3,信息图 16:9 / 16:10,截图再设计 16:10,图文混排小图 3:2 / 3:4,网格图统一高度裁切
 - 生成后的图片放到 `images/` 下,命名遵守 `{页号}-{语义}.{ext}`
 
+#### MiniMax image generation adapter (optional)
+
+When the user explicitly chooses MiniMax, read `references/minimax-image-generation.md` and run the bundled adapter with `MINIMAX_API_KEY` already set in the environment:
+
+```bash
+node "<SKILL_ROOT>/scripts/generate-minimax-image.mjs" \
+  --region global_en \
+  --model image-01 \
+  --prompt "[short deck image prompt]" \
+  --aspect-ratio 16:9 \
+  --output "项目/XXX/ppt/images/03-concept.png"
+```
+
+Choose `global_en` or `cn_zh` to match the account region. The adapter downloads URL responses immediately, decodes base64 responses when requested, and writes the final asset directly into the deck `images/` directory.
+
 ### Step 2 · 拷贝模板
 
 **根据 Step 1 选定的风格,拷贝对应的模板**到目标位置（通常是 `项目/XXX/ppt/index.html`），同时在同级建一个 `images/` 文件夹准备接图片。
@@ -554,6 +569,8 @@ guizang-ppt-skill/
 │   ├── screenshot-backgrounds/ ← 截图美化内置背景(WebP):style-a 5 套 / style-b 4 套
 │   └── motion.min.js         ← Motion One 本地副本（离线兜底,约 64KB,共用）
 ├── scripts/
+│   ├── generate-minimax-image.mjs ← MiniMax text-to-image adapter with regional endpoint and response handling
+│   ├── generate-minimax-image.test.mjs ← Adapter unit tests with mocked image responses
 │   ├── validate-swiss-deck.mjs ← 风格 B 静态校验:登记版式、图片槽位、SVG 文本、标题对齐
 │   └── validate-presenter-mode.mjs ← 两种风格共用:页面 ID、演讲备注、时长和演讲者运行时校验
 └── references/
@@ -565,6 +582,7 @@ guizang-ppt-skill/
     ├── themes.md             ← 风格 A · 5 套主题色预设（只能选不能自定义）
     ├── themes-swiss.md       ← 风格 B · 4 套瑞士风主题色预设（IKB / 柠檬黄 / 柠檬绿 / 安全橙）
     ├── image-prompts.md      ← GPT-M 2.0 配图类型、比例和基础提示词
+    ├── minimax-image-generation.md ← MiniMax text-to-image adapter usage and response handling
     ├── screenshot-framing.md ← CleanShot X 式截图适配语义 + 内置背景资产映射
     ├── presenter-mode.md     ← 演讲者 UI、AI 备注结构、观众屏同步与恢复契约
     └── checklist.md          ← 质量检查清单（P0/P1/P2/P3 分级）
@@ -582,7 +600,7 @@ guizang-ppt-skill/
    - 风格 A → `layouts.md`(顶部有 Pre-flight 类名清单、主题节奏规划、动效 recipe 决策树)
    - 风格 B → **先读 `swiss-layout-lock.md`**,再读 `layouts-swiss.md`;正文页必须从 S01-S22 选择,每页写 `data-layout`
 5. 如果风格 B 需要地点、路线、人物住所或城市关系地图,读 `swiss-map-component.md`
-6. 如果在 Codex 中生成配图,读 `image-prompts.md` 挑图片类型、比例和基础提示词;如果是用户原始截图,先读 `screenshot-framing.md`,优先使用 `assets/screenshot-backgrounds/` 的内置背景资产
+6. 如果在 Codex 中生成配图,读 `image-prompts.md` 挑图片类型、比例和基础提示词;使用 MiniMax API 时再读 `minimax-image-generation.md`;如果是用户原始截图,先读 `screenshot-framing.md`,优先使用 `assets/screenshot-backgrounds/` 的内置背景资产
 7. 细节调整时读 `components.md` 查组件(含 Motion 动效系统章节,主要服务风格 A;风格 B 的组件细节在 `layouts-swiss.md` 附录)
 8. 正式演讲先读 `presenter-mode.md`,生成稳定页面 ID 和 `SPEAKER_NOTES`
 9. 生成后先运行 `validate-presenter-mode.mjs`;风格 B 再运行 `validate-swiss-deck.mjs`,最后读 `checklist.md` 自检

--- a/references/minimax-image-generation.md
+++ b/references/minimax-image-generation.md
@@ -1,0 +1,51 @@
+# MiniMax Image Generation
+
+Use the bundled Node.js adapter when a deck needs text-to-image assets generated through MiniMax. The adapter uses only built-in Node.js APIs and requires Node.js 18 or newer.
+
+## Configuration
+
+- API key environment variable: `MINIMAX_API_KEY`
+- Default model: `image-01`
+- Supported models: `image-01, image-01-live`
+- Default response format: `url`
+- Supported response formats: `url, base64`
+
+| Region | Endpoint |
+|---|---|
+| `global_en` | `https://api.minimax.io/v1/image_generation` |
+| `cn_zh` | `https://api.minimaxi.com/v1/image_generation` |
+
+Keep the API key in the environment. Do not pass it as a command-line argument or write it into deck files.
+
+## Generate One Deck Image
+
+```bash
+node "<SKILL_ROOT>/scripts/generate-minimax-image.mjs" \
+  --region global_en \
+  --model image-01 \
+  --prompt "Editorial documentary scene with generous negative space" \
+  --aspect-ratio 16:9 \
+  --output "project/ppt/images/03-editorial-scene.png"
+```
+
+Use `--region cn_zh` for the China endpoint. Use `--model image-01-live` when live image generation is required.
+
+The adapter sends `model`, `prompt`, `response_format`, and `n`. It also supports `aspect_ratio`, `width`, `height`, `seed`, and `prompt_optimizer`.
+
+## Response Handling
+
+The adapter reads generated images from `data.image_urls`.
+
+- URL entries are downloaded immediately to the requested deck path.
+- Data URI and raw base64 entries are decoded and written to disk.
+- Multiple images add `-1`, `-2`, and later numeric suffixes before the extension.
+- Generated URLs expire after 24 hours, so the adapter never leaves a temporary URL in the deck.
+
+The command prints a JSON summary containing saved file paths and response counts. It never prints the API key.
+
+## Checks
+
+```bash
+node --test scripts/generate-minimax-image.test.mjs
+node scripts/generate-minimax-image.mjs --help
+```

--- a/scripts/generate-minimax-image.mjs
+++ b/scripts/generate-minimax-image.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+import {mkdir, writeFile} from 'node:fs/promises';
+import {dirname, join, parse, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const PROVIDER_NAME='MiniMax';
+const ENDPOINTS=Object.freeze({
+  global_en:'https://api.minimax.io/v1/image_generation',
+  cn_zh:'https://api.minimaxi.com/v1/image_generation',
+});
+const DEFAULT_MODEL='image-01';
+const MODELS=new Set(["image-01","image-01-live"]);
+const OUTPUT_FORMATS=new Set(["url","base64"]);
+const AUTHORIZATION_SCHEME='Bearer';
+const REQUEST_METHOD='POST';
+const RESPONSE_FIELD='data.image_urls';
+const SUCCESS_COUNT_FIELD='metadata.success_count';
+const FAILED_COUNT_FIELD='metadata.failed_count';
+const STATUS_FIELD='base_resp.status_code';
+const URL_TTL_HOURS=24;
+
+function usage(){
+  return [
+    'Usage:',
+    '  MINIMAX_API_KEY=... node scripts/generate-minimax-image.mjs --prompt <text> --output <path> [options]',
+    '',
+    'Options:',
+    '  --region <global_en|cn_zh>      API region (default: global_en)',
+    `  --model <${[...MODELS].join('|')}>  Image model (default: ${DEFAULT_MODEL})`,
+    '  --aspect-ratio <ratio>          Requested image ratio',
+    '  --width <pixels>                Requested image width',
+    '  --height <pixels>               Requested image height',
+    '  --response-format <url|base64>  Response format (default: url)',
+    '  --seed <integer>                Deterministic seed',
+    '  --n <count>                     Number of images (default: 1)',
+    '  --prompt-optimizer <true|false> Enable or disable prompt optimization',
+    '  --help                          Show this help',
+  ].join('\n');
+}
+
+function readPath(value,path){
+  return path.split('.').reduce((current,key)=>current?.[key],value);
+}
+
+function takeValue(argv,index,flag){
+  const value=argv[index+1];
+  if(value===undefined)throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function parseInteger(value,flag,{min=Number.MIN_SAFE_INTEGER}={}){
+  const number=Number(value);
+  if(!Number.isInteger(number)||number<min)throw new Error(`${flag} must be an integer >= ${min}.`);
+  return number;
+}
+
+function parseBoolean(value,flag){
+  if(value==='true')return true;
+  if(value==='false')return false;
+  throw new Error(`${flag} must be true or false.`);
+}
+
+export function endpointForRegion(region){
+  const endpoint=ENDPOINTS[region];
+  if(!endpoint)throw new Error(`Unsupported region "${region}".`);
+  return endpoint;
+}
+
+export function parseArguments(argv){
+  const options={
+    region:'global_en',
+    model:DEFAULT_MODEL,
+    responseFormat:'url',
+    n:1,
+  };
+
+  for(let index=0;index<argv.length;index++){
+    const flag=argv[index];
+    if(flag==='--help'){options.help=true;continue;}
+    const value=takeValue(argv,index,flag);
+    index++;
+    if(flag==='--prompt')options.prompt=value;
+    else if(flag==='--output')options.output=value;
+    else if(flag==='--region')options.region=value;
+    else if(flag==='--model')options.model=value;
+    else if(flag==='--aspect-ratio')options.aspectRatio=value;
+    else if(flag==='--width')options.width=parseInteger(value,flag,{min:1});
+    else if(flag==='--height')options.height=parseInteger(value,flag,{min:1});
+    else if(flag==='--response-format')options.responseFormat=value;
+    else if(flag==='--seed')options.seed=parseInteger(value,flag);
+    else if(flag==='--n')options.n=parseInteger(value,flag,{min:1});
+    else if(flag==='--prompt-optimizer')options.promptOptimizer=parseBoolean(value,flag);
+    else throw new Error(`Unknown option "${flag}".`);
+  }
+
+  if(options.help)return options;
+  if(!options.prompt?.trim())throw new Error('--prompt is required.');
+  if(!options.output?.trim())throw new Error('--output is required.');
+  endpointForRegion(options.region);
+  if(!MODELS.has(options.model))throw new Error(`Unsupported model "${options.model}".`);
+  if(!OUTPUT_FORMATS.has(options.responseFormat))throw new Error(`Unsupported response format "${options.responseFormat}".`);
+  return options;
+}
+
+export function buildImageRequest(options){
+  const body={
+    model:options.model,
+    prompt:options.prompt,
+    response_format:options.responseFormat,
+    n:options.n,
+  };
+  if(options.aspectRatio!==undefined)body.aspect_ratio=options.aspectRatio;
+  if(options.width!==undefined)body.width=options.width;
+  if(options.height!==undefined)body.height=options.height;
+  if(options.seed!==undefined)body.seed=options.seed;
+  if(options.promptOptimizer!==undefined)body.prompt_optimizer=options.promptOptimizer;
+  return body;
+}
+
+export function parseApiResponse(payload){
+  if(!payload||typeof payload!=='object')throw new Error(`${PROVIDER_NAME} returned an invalid JSON response.`);
+  const statusCode=readPath(payload,STATUS_FIELD);
+  if(statusCode!==undefined&&Number(statusCode)!==0){
+    const message=payload.base_resp?.status_msg||payload.base_resp?.status_message||'Unknown API error';
+    throw new Error(`${PROVIDER_NAME} API error ${statusCode}: ${message}`);
+  }
+  const images=readPath(payload,RESPONSE_FIELD);
+  if(!Array.isArray(images)||images.length===0)throw new Error(`${PROVIDER_NAME} response did not include ${RESPONSE_FIELD}.`);
+  if(images.some(image=>typeof image!=='string'||!image.trim())){
+    throw new Error(`${RESPONSE_FIELD} must contain non-empty strings.`);
+  }
+  return {
+    images,
+    successCount:readPath(payload,SUCCESS_COUNT_FIELD),
+    failedCount:readPath(payload,FAILED_COUNT_FIELD),
+  };
+}
+
+function decodeBase64(value){
+  const normalized=value.replace(/\s+/g,'');
+  if(!normalized||!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized))throw new Error('Image response is neither a URL nor valid base64 data.');
+  return Buffer.from(normalized,'base64');
+}
+
+async function loadImage(entry,fetchImpl){
+  if(/^https?:\/\//i.test(entry)){
+    const response=await fetchImpl(entry);
+    if(!response.ok)throw new Error(`Image download failed with HTTP ${response.status}.`);
+    return {
+      bytes:Buffer.from(await response.arrayBuffer()),
+      contentType:response.headers.get('content-type')||'',
+    };
+  }
+
+  const dataUri=/^data:([^;,]+);base64,(.+)$/s.exec(entry);
+  if(dataUri)return {bytes:decodeBase64(dataUri[2]),contentType:dataUri[1]};
+  return {bytes:decodeBase64(entry),contentType:''};
+}
+
+function extensionForContentType(contentType){
+  const type=contentType.split(';',1)[0].trim().toLowerCase();
+  if(type==='image/jpeg')return '.jpg';
+  if(type==='image/png')return '.png';
+  if(type==='image/webp')return '.webp';
+  return '.bin';
+}
+
+function indexedOutputPath(output,index,count,contentType){
+  const parsed=parse(output);
+  const extension=parsed.ext||extensionForContentType(contentType);
+  const suffix=count>1?`-${index+1}`:'';
+  return join(parsed.dir,`${parsed.name}${suffix}${extension}`);
+}
+
+export async function saveImageResults(entries,output,{fetchImpl=globalThis.fetch}={}){
+  if(typeof fetchImpl!=='function')throw new Error('A fetch implementation is required.');
+  const files=[];
+  for(let index=0;index<entries.length;index++){
+    const image=await loadImage(entries[index],fetchImpl);
+    const file=indexedOutputPath(output,index,entries.length,image.contentType);
+    await mkdir(dirname(file),{recursive:true});
+    await writeFile(file,image.bytes);
+    files.push(resolve(file));
+  }
+  return files;
+}
+
+export async function generateImage(options,{apiKey,fetchImpl=globalThis.fetch}={}){
+  if(!apiKey?.trim())throw new Error('MINIMAX_API_KEY is required.');
+  if(typeof fetchImpl!=='function')throw new Error('Node.js 18 or newer is required for fetch support.');
+
+  const endpoint=endpointForRegion(options.region);
+  const response=await fetchImpl(endpoint,{
+    method:REQUEST_METHOD,
+    headers:{
+      Authorization:`${AUTHORIZATION_SCHEME} ${apiKey}`,
+      'Content-Type':'application/json',
+    },
+    body:JSON.stringify(buildImageRequest(options)),
+  });
+  const responseText=await response.text();
+  let payload;
+  try{payload=JSON.parse(responseText);}
+  catch{throw new Error(`${PROVIDER_NAME} returned non-JSON data with HTTP ${response.status}.`);}
+  if(!response.ok)throw new Error(`${PROVIDER_NAME} request failed with HTTP ${response.status}.`);
+
+  const parsed=parseApiResponse(payload);
+  const files=await saveImageResults(parsed.images,options.output,{fetchImpl});
+  return {
+    provider:PROVIDER_NAME,
+    region:options.region,
+    model:options.model,
+    response_format:options.responseFormat,
+    url_ttl_hours:URL_TTL_HOURS,
+    success_count:parsed.successCount??files.length,
+    failed_count:parsed.failedCount??0,
+    files,
+  };
+}
+
+async function main(){
+  try{
+    const options=parseArguments(process.argv.slice(2));
+    if(options.help){console.log(usage());return;}
+    const result=await generateImage(options,{apiKey:process.env.MINIMAX_API_KEY});
+    console.log(JSON.stringify(result,null,2));
+  }catch(error){
+    console.error(`ERROR ${error.message}`);
+    process.exitCode=1;
+  }
+}
+
+if(process.argv[1]&&resolve(process.argv[1])===fileURLToPath(import.meta.url))await main();

--- a/scripts/generate-minimax-image.test.mjs
+++ b/scripts/generate-minimax-image.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'node:test';
+import {
+  buildImageRequest,
+  endpointForRegion,
+  generateImage,
+  parseApiResponse,
+  parseArguments,
+  saveImageResults,
+} from './generate-minimax-image.mjs';
+
+test('selects the configured regional endpoints',()=>{
+  assert.equal(endpointForRegion('global_en'),'https://api.minimax.io/v1/image_generation');
+  assert.equal(endpointForRegion('cn_zh'),'https://api.minimaxi.com/v1/image_generation');
+  assert.throws(()=>endpointForRegion('unknown'),/Unsupported region/);
+});
+
+test('builds a text-to-image request from CLI options',()=>{
+  const options=parseArguments([
+    '--prompt','Editorial city scene',
+    '--output','images/03-city.png',
+    '--region','cn_zh',
+    '--model','image-01-live',
+    '--aspect-ratio','16:9',
+    '--seed','42',
+    '--n','2',
+    '--prompt-optimizer','false',
+  ]);
+  assert.deepEqual(buildImageRequest(options),{
+    model:'image-01-live',
+    prompt:'Editorial city scene',
+    response_format:'url',
+    n:2,
+    aspect_ratio:'16:9',
+    seed:42,
+    prompt_optimizer:false,
+  });
+});
+
+test('parses image URLs and response metadata',()=>{
+  assert.deepEqual(parseApiResponse({
+    data:{image_urls:['https://images.example/one.png']},
+    metadata:{success_count:1,failed_count:0},
+    base_resp:{status_code:0},
+  }),{
+    images:['https://images.example/one.png'],
+    successCount:1,
+    failedCount:0,
+  });
+  assert.throws(()=>parseApiResponse({
+    base_resp:{status_code:1001,status_msg:'Rejected request'},
+  }),/API error 1001/);
+});
+
+test('saves URL and base64 responses to deterministic paths',async()=>{
+  const directory=await mkdtemp(join(tmpdir(),'minimax-image-test-'));
+  const bytes=Uint8Array.from([137,80,78,71,13,10,26,10]);
+  const fetchImpl=async url=>{
+    assert.equal(url,'https://images.example/generated.png');
+    return {
+      ok:true,
+      status:200,
+      headers:{get:name=>name.toLowerCase()==='content-type'?'image/png':null},
+      arrayBuffer:async()=>bytes.buffer,
+    };
+  };
+
+  try{
+    const files=await saveImageResults([
+      'https://images.example/generated.png',
+      `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`,
+    ],join(directory,'images','slide.png'),{fetchImpl});
+    assert.deepEqual(files.map(file=>file.split('/').at(-1)),['slide-1.png','slide-2.png']);
+    assert.deepEqual(await readFile(files[0]),Buffer.from(bytes));
+    assert.deepEqual(await readFile(files[1]),Buffer.from(bytes));
+  }finally{
+    await rm(directory,{recursive:true,force:true});
+  }
+});
+
+test('posts to the selected region and downloads URL responses',async()=>{
+  const directory=await mkdtemp(join(tmpdir(),'minimax-image-request-test-'));
+  const output=join(directory,'images','hero.png');
+  const bytes=Uint8Array.from([137,80,78,71,13,10,26,10]);
+  const requests=[];
+  const fetchImpl=async (url,options)=>{
+    requests.push({url,options});
+    if(url==='https://api.minimaxi.com/v1/image_generation'){
+      return {
+        ok:true,
+        status:200,
+        text:async()=>JSON.stringify({
+          data:{image_urls:['https://images.example/hero.png']},
+          metadata:{success_count:1,failed_count:0},
+          base_resp:{status_code:0},
+        }),
+      };
+    }
+    assert.equal(url,'https://images.example/hero.png');
+    return {
+      ok:true,
+      status:200,
+      headers:{get:name=>name.toLowerCase()==='content-type'?'image/png':null},
+      arrayBuffer:async()=>bytes.buffer,
+    };
+  };
+
+  try{
+    const options=parseArguments([
+      '--prompt','Editorial hero',
+      '--output',output,
+      '--region','cn_zh',
+      '--width','1600',
+      '--height','900',
+      '--response-format','url',
+    ]);
+    const result=await generateImage(options,{apiKey:'test-key',fetchImpl});
+    assert.equal(requests[0].options.method,'POST');
+    assert.equal(requests[0].options.headers.Authorization,'Bearer test-key');
+    assert.deepEqual(JSON.parse(requests[0].options.body),{
+      model:'image-01',
+      prompt:'Editorial hero',
+      response_format:'url',
+      n:1,
+      width:1600,
+      height:900,
+    });
+    assert.equal(result.files[0],output);
+    assert.deepEqual(await readFile(output),Buffer.from(bytes));
+  }finally{
+    await rm(directory,{recursive:true,force:true});
+  }
+});


### PR DESCRIPTION
Reason: Add a regional MiniMax text-to-image adapter so generated deck assets are persisted instead of leaving expiring response URLs.

Changes:
- Added a dependency-free Node.js CLI for the global and China image generation endpoints.
- Added request validation for the supported image models, output formats, dimensions, seeds, counts, and prompt optimization.
- Added immediate download handling for `data.image_urls`, including URL, data URI, and raw base64 responses.
- Added mocked unit tests and operational usage documentation for deck image paths.

Checks:
- `node --check scripts/generate-minimax-image.mjs`
- `node --check scripts/generate-minimax-image.test.mjs`
- `node --test scripts/generate-minimax-image.test.mjs`
- `node scripts/generate-minimax-image.mjs --help`
- `node scripts/check-presenter-runtime-sync.mjs`
- `git diff --check`
- `git diff --cached --check`
