### PR TITLE
fix: harden template contracts and CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Please attach screenshots for visual changes.
 
 ## Validation
 
+- [ ] `npm run check`
 - [ ] `node scripts/validate-swiss-deck.mjs path/to/index.html`
 - [ ] Manual browser review
 

--- a/.github/workflows/presenter-runtime-sync.yml
+++ b/.github/workflows/presenter-runtime-sync.yml
@@ -2,23 +2,19 @@ name: Presenter runtime sync
 
 on:
   pull_request:
-    paths:
-      - "assets/template*.html"
-      - "scripts/check-presenter-runtime-sync.mjs"
-      - ".github/workflows/presenter-runtime-sync.yml"
   push:
     branches: [main]
-    paths:
-      - "assets/template*.html"
-      - "scripts/check-presenter-runtime-sync.mjs"
-      - ".github/workflows/presenter-runtime-sync.yml"
+
+permissions:
+  contents: read
 
 jobs:
   presenter-runtime-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: node scripts/check-presenter-runtime-sync.mjs
+      - run: npm run check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.backup
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ Screenshots are much more useful than descriptions alone. If possible, include:
 
 Keep PRs focused. A small fix with a screenshot is easier to review than a large rewrite.
 
+Run the complete repository gate before opening a PR:
+
+```bash
+npm run check
+```
+
+It covers the Swiss layout contract, both bundled templates, speaker-note validation, and presenter-runtime synchronization without requiring third-party packages.
+
 For Swiss theme changes:
 
 - Do not invent new default body layouts unless the change is explicitly discussed.
@@ -34,6 +42,8 @@ For Swiss theme changes:
 ```bash
 node scripts/validate-swiss-deck.mjs path/to/index.html
 ```
+
+Use `--static-only` for deterministic CI checks. Use `--allow-experimental` only when the deck owner explicitly requested P23/P24; it does not permit arbitrary layout IDs.
 
 For template changes:
 

--- a/README.en.md
+++ b/README.en.md
@@ -245,7 +245,10 @@ Swiss validation:
 
 ```bash
 node scripts/validate-swiss-deck.mjs path/to/index.html
+node scripts/validate-swiss-deck.mjs path/to/index.html --static-only
 ```
+
+The default command adds rendered measurements when Playwright is available. Use `--static-only` for deterministic contract checks in CI. P23/P24 require an explicit user request for experimental layouts and the additional `--allow-experimental` flag.
 
 ## Codex Image Flow
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,10 @@ node scripts/validate-presenter-mode.mjs path/to/index.html --target-minutes 30
 
 ```bash
 node scripts/validate-swiss-deck.mjs path/to/index.html
+node scripts/validate-swiss-deck.mjs path/to/index.html --static-only
 ```
+
+默认命令会在 Playwright 可用时追加真实渲染测量;`--static-only` 只跑确定性的契约检查,适合 CI。P23/P24 仅在用户明确要求实验版式时使用,并追加 `--allow-experimental`。
 
 ## Codex 配图能力
 

--- a/assets/template-swiss.html
+++ b/assets/template-swiss.html
@@ -1248,7 +1248,7 @@
      - canvas-card 内首位插入 <canvas class="ascii-bg" aria-hidden="true">,本文件底部 IIFE 自动启动
      - 主标题反白 weight 200,强调字用斜体而非 var(--accent)(底已是蓝,蓝压蓝看不见)
      - 不要再放编号大字"01"——chrome-min 已经标 01/NN -->
-<section class="slide accent" data-animate="hero" data-slide-id="cover">
+<section class="slide accent" data-layout="SWISS-COVER-ASCII" data-animate="hero" data-slide-id="cover">
   <div class="canvas-card">
     <canvas class="ascii-bg" aria-hidden="true"></canvas>
     <div class="chrome-min">
@@ -1276,7 +1276,7 @@
 <!-- ============ 示例:最后一页 · Closing Manifesto · 左 IKB+ASCII / 右白底 takeaway ============
      与封面 IKB 首尾呼应,但收束更克制:左半保留 ASCII 呼吸场承载宣言,右半白底列 3 条 takeaway.
      第 03 条用 var(--accent) IKB 蓝强调("单一锚点"原则),首尾形成"色彩闭环". -->
-<section class="slide split" data-animate="split-statement" data-slide-id="closing">
+<section class="slide split" data-layout="SWISS-CLOSING-ASCII" data-animate="split-statement" data-slide-id="closing">
   <div class="canvas-card">
     <div class="split-half">
       <!-- 左半 · IKB 宣言 + ASCII 呼吸场 -->

--- a/assets/template.html
+++ b/assets/template.html
@@ -530,7 +530,7 @@
 
 <!-- ============================================================
      SLIDES 插入区 · 在此处填充所有 <section class="slide ..."> 页面
-     每页模板参考 references/page-patterns.md
+     每页模板参考 references/layouts.md
      页面组件参考 references/components.md
      ============================================================ -->
 
@@ -559,7 +559,7 @@ window.__SPEAKER_NOTES__ = SPEAKER_NOTES;
 /* =============== WebGL 双背景 ===============
    深色页：Holographic Dispersion（全息色散 · 钛金暗流）—— 彩虹微扰、鼠标径向涟漪
    浅色页：Spiral Vortex（旋转涡流 · 银色珍珠）—— domain-warp 流动、无中心
-   修改风格请参考 references/webgl-backgrounds.md
+   主题色参考 references/themes.md;WebGL 参数在下方着色器中集中维护
 */
 const VS = `attribute vec2 position;void main(){gl_Position=vec4(position,0.0,1.0);}`;
 

--- a/docs/unification-plan.md
+++ b/docs/unification-plan.md
@@ -52,7 +52,7 @@
 - **a. 构建脚本**(推荐):`scripts/build-templates.mjs` 把 `src/runtime.js` + 各主题 `src/style-*.css` + 皮肤 HTML 组装成各 template*.html。模板仍是完整单文件,但源头唯一。
 - **b. 文档约定**:不引入构建,把 runtime 段落用 `<!-- SHARED-RUNTIME v3 -->` 注释标记,改动时用脚本校验各份一致。成本低但漂移风险仍在。
 
-当前演讲者模式已先落地 Phase 1b 的防漂移护栏:`scripts/check-presenter-runtime-sync.mjs` 与 `.github/workflows/presenter-runtime-sync.yml`。它不替代长期的共享源提取,但可以防止修改只落到其中一份模板。
+当前演讲者模式已先落地 Phase 1b 的防漂移护栏:`scripts/check-presenter-runtime-sync.mjs` 与 `.github/workflows/presenter-runtime-sync.yml`。工作流保留原有 required-check 名称,但已扩展为运行 `npm run check`,同时覆盖 Swiss layout 契约和两套模板 smoke test。它不替代长期的共享源提取,但可以防止修改只落到其中一份模板。
 
 如果未来合并 Bento 分支,以 `main` 上的演讲者运行时为上游,采用 `main → bento` 的合并方向;不要用旧 Bento 模板反向覆盖 `main`。
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "guizang-ppt-skill",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Quality checks for the Guizang HTML deck skill.",
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/validate-swiss-layout-contract.test.mjs tests/validate-presenter-cli.test.mjs",
+    "validate:templates": "node scripts/check-presenter-runtime-sync.mjs && node scripts/validate-presenter-mode.mjs assets/template.html --runtime-only && node scripts/validate-presenter-mode.mjs assets/template-swiss.html && node scripts/validate-swiss-deck.mjs assets/template-swiss.html --static-only",
+    "check": "npm run test && npm run validate:templates"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/references/checklist.md
+++ b/references/checklist.md
@@ -40,6 +40,8 @@
 node <SKILL_ROOT>/scripts/validate-presenter-mode.mjs path/to/index.html
 ```
 
+正式 deck 为 0 页时必须失败;只有维护未填充页面的空模板时才加 `--runtime-only`。`--target-minutes` 必须提供大于 0 的数字,无效参数不能静默跳过预算检查。
+
 浏览器里关闭观众窗口,确认状态变化;再点击“重新打开观众屏”,确认它恢复到演讲者当前页。再逐项实测内嵌宫格选页返回、计时、排练、自动翻页暂停/恢复、激光笔、圈选、清除、黑屏、白屏、冻结、设置组件和演前检查。缩小浏览器窗口再检查一次:当前页与下一页仍上下排列,两个 iframe 的 `width / height` 仍约等于 `16 / 9`,且没有超出预览容器。
 
 ### 0-S. Swiss locked mode:正文页必须来自原始 22P
@@ -60,7 +62,7 @@ node <SKILL_ROOT>/scripts/validate-swiss-deck.mjs path/to/index.html
 
 **校验会拦截**:
 - 未登记版式 / 缺少 `data-layout`
-- P23/P24 实验结构
+- 默认拦截 P23/P24 实验结构;只有用户明确要求时才用匹配的 `data-layout` 并加 `--allow-experimental`
 - SVG 里写可见文字
 - S22 图片未绑定 `s22-hero-21x9`
 - S22 照片使用 `object-position:top center`

--- a/references/layouts-swiss.md
+++ b/references/layouts-swiss.md
@@ -10,7 +10,7 @@
 
 本主题的 golden source 是仓库内的 `assets/template-swiss.html`(由作者本机的原始参考 PPT 派生;原始文件不随仓库分发,`swiss-layout-lock.md` 登记的 S01-S22 即其版式快照)。
 
-生成正文页时不要把 Swiss 当成“自由组合的风格包”。默认只能使用 `references/swiss-layout-lock.md` 登记的 `S01-S22`。每个 slide 都必须在 `<section>` 上写 `data-layout="Sxx"`。
+生成正文页时不要把 Swiss 当成“自由组合的风格包”。默认只能使用 `references/swiss-layout-lock.md` 登记的 `S01-S22`;内置 ASCII 封面和收尾分别使用 `SWISS-COVER-ASCII`、`SWISS-CLOSING-ASCII`。每个 slide 都必须在 `<section>` 上写对应的 canonical `data-layout`。
 
 **关键约束**:
 
@@ -253,7 +253,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:封面 / 章节首页 / 主题宣言。**纯文字结构**(主标题 + 副标 + 元信息),不承载数据。
 
 **默认推荐:IKB 满屏 + ASCII 呼吸场** ⭐
-- `<section class="slide accent">` 满屏 IKB,**不是** light 白底
+- `<section class="slide accent" data-layout="SWISS-COVER-ASCII">` 满屏 IKB,**不是** light 白底
 - `.canvas-card` 内首位插入 `<canvas class="ascii-bg" aria-hidden="true">`,模板底部 IIFE 自动驱动 sin/cos 二维噪声呼吸场
 - 主标题反白 weight 200,微强调字用斜体(`font-style:italic;font-weight:300`)而非 IKB 蓝(底已是蓝、蓝压蓝看不见)
 - **不要**再放编号大字"01"——chrome-min 已经标 01/NN
@@ -264,7 +264,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 
 **示例代码(IKB 默认变体)**:
 ```html
-<section class="slide accent" data-animate="hero">
+<section class="slide accent" data-layout="SWISS-COVER-ASCII" data-animate="hero" data-slide-id="deck-cover">
   <div class="canvas-card">
     <canvas class="ascii-bg" aria-hidden="true"></canvas>
     <div class="chrome-min">
@@ -286,23 +286,21 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 </section>
 ```
 
-**经典变体(左 ink + 右 paper 对开)** — 仅当全 IKB 不合内容调性时使用:
+**经典视觉片段(左 ink + 右 paper 对开)** — 仅用于理解组件组合,不是完整的登记版式;正式生成必须从 `swiss-layout-lock.md` 选择 canonical 骨架:
 ```html
-<section class="slide" data-animate="cover-reveal">
-  <div class="canvas-card cover-split">
-    <div class="cover-ink">
-      <span class="t-cat">Volume 18 · 2026</span>
-      <h1 class="h-hero">Thin Harness,<br>Fat Skills.</h1>
-      <span class="t-meta">— Kevin · 2026-05</span>
-    </div>
-    <div class="cover-paper">
-      <p class="lead">薄型承载层,厚重技能。</p>
-      <ul class="meta-list">
-        <li>22 PAGES</li><li>SWISS · IKB</li><li>MP-75</li>
-      </ul>
-    </div>
+<div class="canvas-card cover-split">
+  <div class="cover-ink">
+    <span class="t-cat">Volume 18 · 2026</span>
+    <h1 class="h-hero">Thin Harness,<br>Fat Skills.</h1>
+    <span class="t-meta">— Kevin · 2026-05</span>
   </div>
-</section>
+  <div class="cover-paper">
+    <p class="lead">薄型承载层,厚重技能。</p>
+    <ul class="meta-list">
+      <li>22 PAGES</li><li>SWISS · IKB</li><li>MP-75</li>
+    </ul>
+  </div>
+</div>
 ```
 
 ---
@@ -313,11 +311,11 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**带量化数据的时间演化**。每节点必须有「年份 + 量化数值(如 1× / 4× 倍数 / 单位数字)+ 描述」三件套。如果只有节点名没有数据,改用 P11 横向时间线。
 **骨架**:左侧 axis 列 12px 圆点 + 1px 虚线轴 / 右侧节点信息(年份 + 大字数据 + 小标 + 描述)。
 **关键类**:`.timeline-v` `.tl-node` `.tl-axis`(12px 固定列宽,绝对定位 dot 防错位) `.kpi-row-4`
-**动效 recipe**:`timeline-vertical` — 节点按时间顺序由上到下点亮(dot 先 pop 再扩 → 文字横向滑入)
+**动效 recipe**:`progression` — 节点按时间顺序由上到下点亮(dot 先 pop 再扩 → 文字横向滑入)
 **网格规则**:axis 列 = 12px 固定;dot 用 `position:absolute;left:50%;transform:translateX(-50%)` 与虚线对齐
 **示例代码**:
 ```html
-<section class="slide" data-animate="timeline-vertical">
+<section class="slide" data-layout="S02" data-animate="progression" data-slide-id="progression-timeline">
   <div class="canvas-card">
     <header class="chrome-min">...</header>
     <div class="timeline-v">
@@ -343,19 +341,17 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**纯定性论断 / 口号 / 章节切换**。一句话压缩到 8-12 词,**不承载任何数据或列表**。如果需要数据支撑,改用 P18 Why Now;如果是封面,用 P1。
 **骨架**:左 1/3 空白 + 中段巨字陈述(8-10vw, weight 200) + 右下小字注脚 + 底部 hairline。
 **关键类**:`.h-statement`(9.6vw,letter-spacing:-.05em) `.stmt-anchor`
-**动效 recipe**:`statement-rise` — 大字按词序错峰升起(每词延迟 180ms)+ 注脚 fade in
-**示例代码**:
+**动效 recipe**:`statement` — 大字按词序错峰升起(每词延迟 180ms)+ 注脚 fade in
+**排版片段**:下面只展示 statement 的文字层;正式页面必须套入 `swiss-layout-lock.md` 登记的 `S03` 或 `S09` 完整骨架,不要把片段直接当成 slide。
 ```html
-<section class="slide" data-animate="statement-rise">
-  <div class="canvas-card">
-    <header class="chrome-min">...</header>
-    <h1 class="h-statement">
-      <span>Build it</span> <span>once.</span><br>
-      <span>It runs</span> <span>forever.</span>
-    </h1>
-    <span class="stmt-anchor">— Statement 03</span>
-  </div>
-</section>
+<div class="canvas-card">
+  <header class="chrome-min">...</header>
+  <h1 class="h-statement">
+    <span>Build it</span> <span>once.</span><br>
+    <span>It runs</span> <span>forever.</span>
+  </h1>
+  <span class="stmt-anchor">— Statement 03</span>
+</div>
 ```
 
 ---
@@ -366,7 +362,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**6 个对等概念 / 功能列举**(数量必须 = 6,过少用 P5,过多用 P15/P16)。每格仅承载「图标 + 编号 + 短标题 + 一行描述」,**不承载需要展开的数据 / 段落**。
 **骨架**:2×3 网格 / 每格上方 lucide 图标 + 编号 + 短标题 + 一行描述 / 单元间用 hairline 分隔。
 **关键类**:`.cell-6` `.cell-icon-row` `.cell-num`
-**动效 recipe**:`six-cells` — 6 格按 z 形顺序点亮(L→R, T→B,每格延迟 90ms)
+**动效 recipe**:`grid-reveal` — 6 格按 z 形顺序点亮(L→R, T→B,每格延迟 90ms)
 **注意**:**不要自己画 SVG 图标**,用 `<i data-lucide="bookmark"></i>` 引线上 lucide。
 **示例代码**:
 ```html
@@ -389,7 +385,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**3 个对等概念 / 步骤**(数量必须 = 3)。结构同质、**无强烈数据差异**(若数据可比,改用 P6 KPI Tower)。每卡内容比 P4 略多(编号 + 标题 + 1-2 行描述)。
 **骨架**:左侧大标题 + 描述 + 顶部 hairline / 右侧 3 张水平堆叠 sub-card。
 **关键类**:`.sub-card-stack` `.sub-card`(`.card-fill` 灰底,直角)
-**动效 recipe**:`sub-stack` — 主标题先入 → 3 卡阶梯式从右滑入(每卡延迟 140ms)
+**动效 recipe**:`grid-reveal` — 主标题先入 → 3 卡阶梯式从右滑入(每卡延迟 140ms)
 **示例代码**:
 ```html
 <div class="grid-2-9">
@@ -416,7 +412,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**4 项可比量化数据**(必须有真实数值,bar 高度由数据决定)。典型如:成本、容量、计数、效率指标。**禁止**用于无数据的概念列举(那是 P4/P5 的事)。
 **骨架**:4 列均分,每列底部一根不同高度的 IKB 蓝矩形(数据决定高度)+ 顶部图标 + 中段巨数 + 底部标签。
 **关键类**:`.kpi-tower-row` `.bar-tower`(min-height:6vh, max:36vh) `.tower-cap`
-**动效 recipe**:`tower-grow` — 标签先入 → 数字 scale 弹入 → tower scaleY 从 0 拉起(transform-origin:bottom)
+**动效 recipe**:`measure-up` — 标签先入 → 数字 scale 弹入 → tower scaleY 从 0 拉起(transform-origin:bottom)
 **示例代码**:
 ```html
 <div class="kpi-tower-row">
@@ -438,7 +434,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**5-10 项可比量化数据**(必须有真实百分比 / 评分 / 数值,bar 宽度由数据决定)。典型如:benchmark 排名、市场份额、问卷占比。⚠️ **严禁用于无量化数据的概念列举**(那是 P4/P5/P15)— 编造数字会被识破。
 **骨架**:顶部大标题 / 中段空 / 下半部条形列表(每行:文字标签 + 1px 蓝条 0→target width + 末端数字)。
 **关键类**:`.h-bar-chart` `.bar-row` `.bar-fill`(scaleX 动画)
-**动效 recipe**:`hbar-grow` — 大标题先入 → 每行依序 width 0→target(transform-origin:left)+ 末端数字 count-up
+**动效 recipe**:`bar-grow` — 大标题先入 → 每行依序 width 0→target(transform-origin:left)+ 末端数字 count-up
 **示例代码**:
 ```html
 <div class="h-bar-chart">
@@ -483,7 +479,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**deck 收尾**(每个 deck 只有一页)。固定结构:左侧宣言短句 + 右侧 3 条 takeaway(编号 + 标题 + 一行说明)。**不能在中间页使用**(那会与 P1 封面重复)。
 
 **默认推荐:左 IKB+ASCII / 右 paper takeaway** ⭐
-- 用 `<section class="slide split">` + 左半 `.half.b-accent` + ASCII canvas + 右半白底 takeaway
+- 用 `<section class="slide split" data-layout="SWISS-CLOSING-ASCII">` + 左半 `.half.b-accent` + ASCII canvas + 右半白底 takeaway
 - 与 P1 封面的全 IKB 形成"开场全 IKB ↔ 收尾半 IKB"色彩闭环
 - 右侧第 03 条 takeaway 用 `var(--accent)` 强调,把 IKB 蓝从左半穿到右半,完成色彩缝合
 - 大标题反白 weight 200,强调字用斜体(底已是蓝、不要再用 `var(--accent)` 标蓝)
@@ -493,7 +489,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 
 **示例代码(IKB 默认变体)**:
 ```html
-<section class="slide split" data-animate="split-statement">
+<section class="slide split" data-layout="SWISS-CLOSING-ASCII" data-animate="split-statement" data-slide-id="deck-closing">
   <div class="canvas-card">
     <div class="split-half">
       <!-- 左半 · IKB + ASCII 呼吸场 -->
@@ -548,7 +544,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 **适用内容类型**:**口号 / 隐喻 / 章节切换**(同 P3,但加几何点阵装饰)。用于一个 deck 内**避免连续两页都是 P3**;通常用作"概念定义"前的视觉调味页。
 **骨架**:中段 7vw 巨字三行宣言 / 右上角 36vw 圆点矩阵 + 左下角描边圆环矩阵。
 **关键类**:`.dot-mat`(SVG mask 实心点)`.ring-mat`(描边圆)`.cross-mat`(× 网格)
-**动效 recipe**:`matrix-statement` — 文字逐行入 → 点阵 mask-position 从左推到右
+**动效 recipe**:`statement` — 文字逐行入 → 点阵随内容渐显
 **示例代码**:
 ```html
 <div class="canvas-card">
@@ -707,10 +703,10 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 
 **示例代码**:
 ```html
-<section class="slide light" data-animate="image-hero">
+<section class="slide light" data-layout="S22" data-animate="image-hero" data-slide-id="image-evidence">
   <div class="canvas-card" style="padding:0;display:flex;flex-direction:column;overflow:hidden">
     <div data-anim="img" style="position:relative;flex:0 0 60%;overflow:hidden;background:var(--grey-1)">
-      <img src="images/22-product-scene.png" alt="[必填] 图片说明" loading="eager"
+      <img src="images/22-product-scene.png" alt="[必填] 图片说明" loading="eager" data-image-slot="s22-hero-21x9"
            style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:center 30%">
       <div class="chrome-min" style="position:absolute;top:0;left:0;right:0;color:rgba(255,255,255,.9);padding:5.6vh 5vw 0">
         <div class="l">Section · Case / Visual Evidence</div>
@@ -740,7 +736,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 
 ## 历史实验区(默认禁用)
 
-下面的 P23/P24 是早期为了探索图文混排加入的实验版式。它们不属于原始 22P,默认不要用于正式生成。除非用户明确说“我要实验新图文版式”,否则请使用 S22 或 S15/S16 的图片槽位。
+下面的 P23/P24 是早期为了探索图文混排加入的实验版式。它们不属于原始 22P,默认不要用于正式生成。除非用户明确说“我要实验新图文版式”,否则请使用 S22 或 S15/S16 的图片槽位。明确启用后用 `--allow-experimental` 校验;这个开关只放行 P23/P24,不会放行其他自定义 ID。
 
 ### P23 · Swiss Image Split · 左文右图 / 右文左图(实验,默认禁用)
 
@@ -758,7 +754,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 - 右图宽度大,标题不要超过 3 行,正文控制在 2-3 个短段或 3 条 bullet
 
 ```html
-<section class="slide light" data-animate="grid-reveal">
+<section class="slide light" data-layout="P23" data-animate="grid-reveal" data-slide-id="visual-argument">
   <div class="canvas-card">
     <div class="chrome-min">
       <div class="l">Section · Visual Argument</div>
@@ -777,7 +773,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
         </div>
         <figure class="tile">
           <div class="frame-img r-16x10 fit-contain">
-            <img src="images/23-visual-evidence.png" alt="[必填] 图片说明">
+            <img src="images/23-visual-evidence.png" alt="[必填] 图片说明" data-image-slot="p23-visual-16x10">
           </div>
           <figcaption class="swiss-img-caption"><strong>[必填] 图片标题</strong><span>16:10 · fit-contain</span></figcaption>
         </figure>
@@ -803,7 +799,7 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 - 如果用户原始截图比例混乱,先按 `screenshot-framing.md` 做 CleanShot X 式程序化适配;只有太长、太窄或需要重构信息时,才用 GPT-M 2.0 重生成同一比例的"截图再设计"
 
 ```html
-<section class="slide light" data-animate="grid-reveal">
+<section class="slide light" data-layout="P24" data-animate="grid-reveal" data-slide-id="evidence-grid">
   <div class="canvas-card">
     <div class="chrome-min">
       <div class="l">Section · Evidence Grid</div>
@@ -815,9 +811,9 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
         <h2 style="font-family:var(--sans),var(--sans-zh);font-weight:200;font-size:min(6.6vw,11.6vh);line-height:.96;letter-spacing:-.035em">[必填] 三个证据,一个结论</h2>
       </div>
       <div class="swiss-img-grid" data-anim="up">
-        <figure class="tile"><div class="frame-img h-26 fit-contain"><img src="images/24-proof-a.png" alt="[必填]"></div><figcaption class="swiss-img-caption"><strong>01</strong><span>[必填] 证据 A</span></figcaption></figure>
-        <figure class="tile"><div class="frame-img h-26 fit-contain"><img src="images/24-proof-b.png" alt="[必填]"></div><figcaption class="swiss-img-caption"><strong>02</strong><span>[必填] 证据 B</span></figcaption></figure>
-        <figure class="tile"><div class="frame-img h-26 fit-contain swiss-lined"><img src="images/24-proof-c.png" alt="[必填]"></div><figcaption class="swiss-img-caption"><strong>03</strong><span>[必填] 关键证据</span></figcaption></figure>
+        <figure class="tile"><div class="frame-img h-26 fit-contain"><img src="images/24-proof-a.png" alt="[必填]" data-image-slot="p24-proof-a"></div><figcaption class="swiss-img-caption"><strong>01</strong><span>[必填] 证据 A</span></figcaption></figure>
+        <figure class="tile"><div class="frame-img h-26 fit-contain"><img src="images/24-proof-b.png" alt="[必填]" data-image-slot="p24-proof-b"></div><figcaption class="swiss-img-caption"><strong>02</strong><span>[必填] 证据 B</span></figcaption></figure>
+        <figure class="tile"><div class="frame-img h-26 fit-contain swiss-lined"><img src="images/24-proof-c.png" alt="[必填]" data-image-slot="p24-proof-c"></div><figcaption class="swiss-img-caption"><strong>03</strong><span>[必填] 关键证据</span></figcaption></figure>
       </div>
     </div>
   </div>
@@ -852,8 +848,8 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 | 产品规格 / benchmark | P21 Tech Spec |
 | 案例图 + 数据落地 | P22 Image Hero |
 | 地点 / 路线 / 人物住所关系 | S08 + Swiss Map Component |
-| 单图解释论点 / 图文混排 | P23 Swiss Image Split |
-| 2-3 张图片/截图/图表证据链 | P24 Swiss Evidence Grid |
+| 单图解释论点 / 图文混排 | 默认 S22 Image Hero(主图 + 3 项数据);无数据时改造 S16 卡片;仅在用户明确要求实验版式时用 P23 |
+| 2-3 张图片/截图/图表证据链 | 默认 S15/S16 图片格改造;仅在用户明确要求实验版式时用 P24 |
 
 ---
 
@@ -876,8 +872,8 @@ Swiss 主题有 22 个登记版式,生成时要主动展示版式系统,不要�
 | 多步骤流程(无数据) | P11 Horizontal Timeline | |
 | 8-12 项同类 | P15 Image Matrix | |
 | deck 收尾 | P9 Closing(每 deck 仅 1 次) | |
-| 1 张核心图片 + 一段解释 | P23 Swiss Image Split | P22(除非图片是主角且有 KPI) |
-| 2-3 张同类图片 | P24 Evidence Grid | P4/P16(文字卡片,不是图片证据) |
+| 1 张核心图片 + 一段解释 | S22(图片为主角且有 3 项数据) / S16 卡片改造 | 默认使用 P23(除非用户明确要求实验版式) |
+| 2-3 张同类图片 | S15/S16 图片格改造 | 默认使用 P24(除非用户明确要求实验版式) |
 
 **雷区案例**:用 P7 H-Bar Chart 展示「智能补全 / 实时协作 / 自主代理」这种**无可比百分比的概念列举**,编造 96/88/78 之类数字 → **数据不可信,版式滥用**。这种内容应该用 P2(若有时间维度)或 P3 Statement(若是论断)。
 

--- a/references/presenter-mode.md
+++ b/references/presenter-mode.md
@@ -179,6 +179,8 @@ node <SKILL_ROOT>/scripts/validate-presenter-mode.mjs path/to/index.html
 node <SKILL_ROOT>/scripts/validate-presenter-mode.mjs path/to/index.html --target-minutes 30
 ```
 
+正式 deck 没有 slide 时校验失败。只有维护尚未填充页面的空模板时才使用 `--runtime-only`;`--target-minutes` 缺值、非数字或不大于 0 时属于命令用法错误并返回退出码 2。
+
 浏览器实测至少包含：进入演讲模式、弹窗允许/拦截、前后翻页且预览 iframe 不重载、内嵌宫格替换预览与选页返回、首页/尾页、尾页预览结束态、尾页重新开始、观众窗口关闭后显示“未连接”、重新打开后恢复同步、退出演讲后观众屏关闭或显示结束遮罩、备注保存、计时、排练记录、自动翻页暂停/恢复、激光笔、圈选、清除、黑屏、白屏、冻结、设置面板与演前检查。
 
 至少在一组常用尺寸和一组小屏尺寸下检查：当前页/下一页上下排列，两个 iframe 宽高比均为 `16:9`，且没有超出各自容器。

--- a/scripts/validate-presenter-mode.mjs
+++ b/scripts/validate-presenter-mode.mjs
@@ -2,13 +2,33 @@
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 
-const file=process.argv[2];
-const targetArg=process.argv.find(x=>x.startsWith('--target-minutes='));
-const targetIndex=process.argv.indexOf('--target-minutes');
-const targetMinutes=Number(targetArg?.split('=')[1]??(targetIndex>=0?process.argv[targetIndex+1]:NaN));
+const [file,...args]=process.argv.slice(2);
+let targetMinutes=NaN;
+let targetProvided=false;
+let runtimeOnly=false;
+let cliError='';
 
-if(!file){
-  console.error('Usage: node scripts/validate-presenter-mode.mjs <index.html> [--target-minutes 30]');
+for(let i=0;i<args.length;i++){
+  const arg=args[i];
+  if(arg==='--runtime-only'){
+    runtimeOnly=true;
+  }else if(arg==='--target-minutes'){
+    targetProvided=true;
+    const value=args[++i];
+    if(value===undefined||value.startsWith('--'))cliError='--target-minutes requires a positive number.';
+    else targetMinutes=Number(value);
+  }else if(arg.startsWith('--target-minutes=')){
+    targetProvided=true;
+    targetMinutes=Number(arg.slice('--target-minutes='.length));
+  }else{
+    cliError=`Unknown option: ${arg}`;
+  }
+}
+
+if(!file||file.startsWith('--')||cliError||(targetProvided&&(!Number.isFinite(targetMinutes)||targetMinutes<=0))){
+  if(cliError)console.error(`ERROR ${cliError}`);
+  else if(targetProvided)console.error('ERROR --target-minutes requires a positive number.');
+  console.error('Usage: node scripts/validate-presenter-mode.mjs <index.html> [--target-minutes 30] [--runtime-only]');
   process.exit(2);
 }
 
@@ -39,7 +59,11 @@ function extractArray(name){
 
 const slideTags=[...source.matchAll(/<section\b(?=[^>]*\bclass="[^"]*\bslide\b[^"]*")[^>]*>/g)].map(m=>m[0]);
 const slideIds=slideTags.map((tag,i)=>tag.match(/\bdata-slide-id="([^"]+)"/)?.[1]||'');
-if(!slideIds.length)warnings.push('No slides found; only the reusable presenter runtime can be validated.');
+if(!slideIds.length){
+  const message='No slides found; only the reusable presenter runtime can be validated.';
+  if(runtimeOnly)warnings.push(message);
+  else errors.push(`${message} Pass --runtime-only only when checking an intentionally empty template.`);
+}
 
 slideIds.forEach((id,i)=>{
   if(!id)errors.push(`Slide ${i+1}: missing data-slide-id.`);

--- a/scripts/validate-swiss-deck.mjs
+++ b/scripts/validate-swiss-deck.mjs
@@ -6,9 +6,10 @@ import { pathToFileURL } from 'node:url';
 
 const file = process.argv[2];
 const allowExperimental = process.argv.includes('--allow-experimental');
+const staticOnly = process.argv.includes('--static-only');
 
 if (!file) {
-  console.error('Usage: node scripts/validate-swiss-deck.mjs <index.html> [--allow-experimental]');
+  console.error('Usage: node scripts/validate-swiss-deck.mjs <index.html> [--allow-experimental] [--static-only]');
   process.exit(2);
 }
 
@@ -42,10 +43,15 @@ async function loadPlaywright() {
   return null;
 }
 
-const allowedLayouts = new Set([
+const registeredLayouts = new Set([
   'SWISS-COVER-ASCII',
   'SWISS-CLOSING-ASCII',
   ...Array.from({ length: 22 }, (_, i) => `S${String(i + 1).padStart(2, '0')}`),
+]);
+const experimentalLayouts = new Set(['P23', 'P24']);
+const experimentalStructures = new Map([
+  ['P23', /\bclass="[^"]*\bswiss-img-split\b[^"]*"/],
+  ['P24', /\bclass="[^"]*\bswiss-img-grid\b[^"]*"/],
 ]);
 
 const slideRe = /<section\b[^>]*class="[^"]*\bslide\b[^"]*"[^>]*>[\s\S]*?<\/section>/g;
@@ -60,12 +66,17 @@ slides.forEach((slide) => {
 
   if (!layout) {
     errors.push(`Slide ${slide.idx}: missing data-layout. Swiss locked mode requires S01-S22 or SWISS-COVER-ASCII/SWISS-CLOSING-ASCII.`);
-  } else if (!allowedLayouts.has(layout)) {
+  } else if (experimentalLayouts.has(layout)) {
+    if (!allowExperimental) errors.push(`Slide ${slide.idx}: data-layout="${layout}" is experimental. Pass --allow-experimental only when the user explicitly requests it.`);
+    if (!experimentalStructures.get(layout).test(slide.html)) errors.push(`Slide ${slide.idx}: data-layout="${layout}" must use its matching experimental structure.`);
+  } else if (!registeredLayouts.has(layout)) {
     errors.push(`Slide ${slide.idx}: data-layout="${layout}" is not registered in swiss-layout-lock.md.`);
   }
 
-  if (!allowExperimental && /\bdata-layout="P2[34]\b|Swiss Image Split|Swiss Evidence Grid|swiss-img-split|swiss-img-grid/.test(slide.html)) {
-    errors.push(`Slide ${slide.idx}: uses experimental P23/P24 image structure. Use S22 or S15/S16 image-grid adaptations instead.`);
+  for (const [expectedLayout, structure] of experimentalStructures) {
+    if (structure.test(slide.html) && layout !== expectedLayout) {
+      errors.push(`Slide ${slide.idx}: uses the ${expectedLayout} experimental structure but declares data-layout="${layout || 'missing'}".`);
+    }
   }
 
   const isStatement = layout === 'S03' || layout === 'S09' || layout === 'S10' || layout === 'SWISS-COVER-ASCII' || layout === 'SWISS-CLOSING-ASCII';
@@ -295,7 +306,7 @@ async function runRenderedMeasurements() {
   }
 }
 
-await runRenderedMeasurements();
+if (!staticOnly) await runRenderedMeasurements();
 
 if (warnings.length) {
   console.warn('Warnings:');

--- a/tests/validate-presenter-cli.test.mjs
+++ b/tests/validate-presenter-cli.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const validator = resolve(root, 'scripts/validate-presenter-mode.mjs');
+const emptyTemplate = resolve(root, 'assets/template.html');
+const populatedTemplate = resolve(root, 'assets/template-swiss.html');
+
+function validate(file, ...args) {
+  const result = spawnSync(process.execPath, [validator, file, ...args], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  return {
+    ...result,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+test('an empty deck fails unless runtime-only validation is explicit', () => {
+  const deckResult = validate(emptyTemplate);
+  const runtimeResult = validate(emptyTemplate, '--runtime-only');
+
+  assert.equal(deckResult.status, 1, deckResult.output);
+  assert.match(deckResult.output, /Pass --runtime-only/);
+  assert.equal(runtimeResult.status, 0, runtimeResult.output);
+  assert.match(runtimeResult.output, /only the reusable presenter runtime/);
+});
+
+for (const args of [
+  ['--target-minutes'],
+  ['--target-minutes', 'nope'],
+  ['--target-minutes=0'],
+  ['--target-minutes=-5'],
+]) {
+  test(`rejects invalid timing option: ${args.join(' ')}`, () => {
+    const result = validate(populatedTemplate, ...args);
+
+    assert.equal(result.status, 2, result.output);
+    assert.match(result.output, /requires a positive number/);
+  });
+}
+
+test('accepts both supported target-minute syntaxes', () => {
+  const spaced = validate(populatedTemplate, '--target-minutes', '2');
+  const equals = validate(populatedTemplate, '--target-minutes=2');
+
+  assert.equal(spaced.status, 0, spaced.output);
+  assert.equal(equals.status, 0, equals.output);
+});
+
+test('rejects unknown options', () => {
+  const result = validate(populatedTemplate, '--typo');
+
+  assert.equal(result.status, 2, result.output);
+  assert.match(result.output, /Unknown option/);
+});

--- a/tests/validate-swiss-layout-contract.test.mjs
+++ b/tests/validate-swiss-layout-contract.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test, { after } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const validator = resolve(root, 'scripts/validate-swiss-deck.mjs');
+const fixtureDir = mkdtempSync(resolve(tmpdir(), 'guizang-swiss-validator-'));
+
+after(() => rmSync(fixtureDir, { recursive: true, force: true }));
+
+function validate(name, slides, ...args) {
+  const file = resolve(fixtureDir, `${name}.html`);
+  writeFileSync(file, `<!doctype html><html><body>${slides}</body></html>`);
+  const result = spawnSync(process.execPath, [validator, file, '--static-only', ...args], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  return {
+    ...result,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+test('accepts registered and bundled special layout IDs', () => {
+  const slides = [
+    '<section class="slide" data-layout="S01"><div>Index cover</div></section>',
+    '<section class="slide light" data-layout="S22"><div class="hero-img-wrap"><img src="https://example.com/hero.png" alt="Hero" data-image-slot="s22-hero-21x9"></div></section>',
+    '<section class="slide accent" data-layout="SWISS-COVER-ASCII"><h1 style="align-self:center">Cover</h1></section>',
+    '<section class="slide split" data-layout="SWISS-CLOSING-ASCII"><h2>Closing</h2></section>',
+  ].join('');
+  const result = validate('registered-layouts', slides);
+
+  assert.equal(result.status, 0, result.output);
+  assert.doesNotMatch(result.output, /Rendered measurement skipped/);
+});
+
+test('rejects missing and unknown layout IDs', () => {
+  const missing = validate('missing-layout', '<section class="slide"><div>Missing</div></section>');
+  const unknownSlide = '<section class="slide" data-layout="S23"><div>Unknown</div></section>';
+  const unknown = validate('unknown-layout', unknownSlide);
+  const unknownWithOptIn = validate('unknown-layout-opted-in', unknownSlide, '--allow-experimental');
+
+  assert.equal(missing.status, 1, missing.output);
+  assert.match(missing.output, /missing data-layout/);
+  assert.equal(unknown.status, 1, unknown.output);
+  assert.match(unknown.output, /not registered/);
+  assert.equal(unknownWithOptIn.status, 1, unknownWithOptIn.output);
+  assert.match(unknownWithOptIn.output, /not registered/);
+});
+
+for (const layout of ['P23', 'P24']) {
+  test(`${layout} requires the explicit experimental opt-in`, () => {
+    const className = layout === 'P23' ? 'swiss-img-split' : 'swiss-img-grid';
+    const slide = `<section class="slide" data-layout="${layout}"><div class="${className}">Experimental</div></section>`;
+    const locked = validate(`${layout.toLowerCase()}-locked`, slide);
+    const optedIn = validate(`${layout.toLowerCase()}-allowed`, slide, '--allow-experimental');
+
+    assert.equal(locked.status, 1, locked.output);
+    assert.match(locked.output, /--allow-experimental/);
+    assert.equal(optedIn.status, 0, optedIn.output);
+  });
+}
+
+test('experimental structures cannot masquerade as registered layouts', () => {
+  const slide = '<section class="slide" data-layout="S08"><div class="swiss-img-split">Wrong contract</div></section>';
+  const result = validate('experimental-structure-with-registered-id', slide, '--allow-experimental');
+
+  assert.equal(result.status, 1, result.output);
+  assert.match(result.output, /P23 experimental structure/);
+});
+
+test('the bundled Swiss template satisfies its own static validator', () => {
+  const result = spawnSync(process.execPath, [validator, resolve(root, 'assets/template-swiss.html'), '--static-only'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+});
+
+test('complete slide examples in the Swiss guide declare their contracts', () => {
+  const guide = readFileSync(resolve(root, 'references/layouts-swiss.md'), 'utf8');
+  const htmlExamples = [...guide.matchAll(/```html\s+([\s\S]*?)```/g)].map((match) => match[1]);
+  const slideTags = htmlExamples.flatMap((example) => [...example.matchAll(/<section\b[^>]*\bclass="[^"]*\bslide\b[^"]*"[^>]*>/g)].map((match) => match[0]));
+  const localImages = htmlExamples.flatMap((example) => [...example.matchAll(/<img\b[^>]*\bsrc="images\/[^"]+"[^>]*>/g)].map((match) => match[0]));
+
+  assert.ok(slideTags.length > 0, 'expected at least one complete slide example');
+  slideTags.forEach((tag) => assert.match(tag, /\bdata-layout="(?:S(?:0[1-9]|1[0-9]|2[0-2])|SWISS-(?:COVER|CLOSING)-ASCII|P2[34])"/, tag));
+  slideTags.forEach((tag) => assert.match(tag, /\bdata-slide-id="[a-z0-9]+(?:-[a-z0-9]+)*"/, tag));
+  localImages.forEach((tag) => assert.match(tag, /\bdata-image-slot="[^"]+"/, tag));
+});
+
+test('every documented Swiss animation recipe is registered by the template', () => {
+  const guide = readFileSync(resolve(root, 'references/layouts-swiss.md'), 'utf8');
+  const template = readFileSync(resolve(root, 'assets/template-swiss.html'), 'utf8');
+  const documented = [...guide.matchAll(/\*\*动效 recipe\*\*:`([^`]+)`/g)].map((match) => match[1]);
+  const recipeBlock = template.match(/const RECIPES = \{([\s\S]*?)\n  \};/)?.[1] ?? '';
+  const registered = new Set([...recipeBlock.matchAll(/'([^']+)'\s*:/g)].map((match) => match[1]));
+  const missing = [...new Set(documented)].filter((recipe) => !registered.has(recipe));
+
+  assert.ok(documented.length > 0, 'expected documented animation recipes');
+  assert.deepEqual(missing, []);
+});
+
+test('template comments only reference files that exist', () => {
+  for (const templateName of ['template.html', 'template-swiss.html']) {
+    const template = readFileSync(resolve(root, 'assets', templateName), 'utf8');
+    const references = new Set([...template.matchAll(/references\/[a-z0-9-]+\.md/gi)].map((match) => match[0]));
+
+    references.forEach((reference) => assert.ok(existsSync(resolve(root, reference)), `${templateName}: missing ${reference}`));
+  }
+});


### PR DESCRIPTION
## Summary

Establish a deterministic repository quality gate and repair the template contracts that currently make the bundled Swiss template fail its own validator.

Refs #55 (Phase 1)

## What Changed

- add canonical layout IDs to the bundled Swiss cover/closing and complete guide examples
- make P23/P24 opt-in work while preventing experimental structures from masquerading as registered Sxx layouts
- align documented animation recipes and repair stale template reference links
- add `--static-only` for deterministic Swiss checks
- make presenter validation reject empty production decks, invalid timing values, and unknown CLI options; add explicit `--runtime-only` for empty templates
- add 16 dependency-free Node regression tests and a single `npm run check` entry point
- expand the existing required-check workflow without changing its workflow/job identity

## Visual QA

No CSS or rendered layout values changed. Template changes are metadata/comments only.

- [x] No visual diff expected
- [x] Existing presenter CSS/JavaScript blocks remain byte-identical across themes

## Validation

- [x] `npm run check`
- [x] `node --check` for both validators and both test files
- [x] Skill Creator `quick_validate.py`
- [x] `git diff --check`

## Notes

The broader P/S naming and documented-class drift remains tracked in #55. This PR deliberately adds the guardrails first so the 22-layout rebuild can proceed against executable fixtures instead of untested prose.

Related: #35, #48, #49, #51, #52.